### PR TITLE
Fix PyInstaller app bundle double-click launch issue

### DIFF
--- a/FittingApp.spec
+++ b/FittingApp.spec
@@ -10,10 +10,22 @@ if os.path.exists('MyIcon.icns'):
 elif os.path.exists('MyIcon.ico'):
     icon_file = 'MyIcon.ico'
 
+# Find Python shared library for conda environments
+python_lib_path = None
+if hasattr(sys, 'base_prefix'):
+    potential_lib = os.path.join(sys.base_prefix, 'lib', f'libpython{sys.version_info.major}.{sys.version_info.minor}.dylib')
+    if os.path.exists(potential_lib):
+        python_lib_path = potential_lib
+
+# Prepare binaries list
+binaries_list = []
+if python_lib_path and sys.platform == 'darwin':
+    binaries_list.append((python_lib_path, 'Frameworks'))
+
 a = Analysis(
     ['main.py'],
     pathex=[],
-    binaries=[],
+    binaries=binaries_list,
     datas=[],
     hiddenimports=[],
     hookspath=[],
@@ -52,7 +64,7 @@ coll = COLLECT(
 # Only create macOS app bundle on macOS
 if sys.platform == 'darwin' and icon_file:
     app = BUNDLE(
-        exe,
+        coll,
         name='FittingApp.app',
         icon=icon_file,
         bundle_identifier=None,

--- a/gui/main_interface.py
+++ b/gui/main_interface.py
@@ -4,14 +4,14 @@ import matplotlib
 
 matplotlib.use("TkAgg")
 
-from interface_DBA_dye_to_host_fitting import DBAFittingAppDtoH
-from interface_DBA_host_to_dye_fitting import DBAFittingAppHtoD
-from interface_dba_merge_fits import DBAMergeFitsApp
-from interface_DyeAlone_fitting import DyeAloneFittingApp
-from interface_GDA_fitting import GDAFittingApp
-from interface_gda_merge_fits import GDAMergeFitsApp
-from interface_IDA_fitting import IDAFittingApp
-from interface_ida_merge_fits import IDAMergeFitsApp
+from gui.interface_DBA_dye_to_host_fitting import DBAFittingAppDtoH
+from gui.interface_DBA_host_to_dye_fitting import DBAFittingAppHtoD
+from gui.interface_dba_merge_fits import DBAMergeFitsApp
+from gui.interface_DyeAlone_fitting import DyeAloneFittingApp
+from gui.interface_GDA_fitting import GDAFittingApp
+from gui.interface_gda_merge_fits import GDAMergeFitsApp
+from gui.interface_IDA_fitting import IDAFittingApp
+from gui.interface_ida_merge_fits import IDAMergeFitsApp
 
 from utils.bmg_to_txt import BMGToTxtConverter
 from utils.plot_replica import PlotReplica


### PR DESCRIPTION
- Add explicit Python shared library inclusion in FittingApp.spec
- Fix import paths in main_interface.py to use proper module references
- Update BUNDLE configuration to include complete COLLECT for .app bundle
- Resolve libpython3.13.dylib missing dependency that prevented app launch