### PR TITLE
fix: solve Windows encoding issues, patch reading results of a single replica

### DIFF
--- a/core/fitting/dba_dye_to_host.py
+++ b/core/fitting/dba_dye_to_host.py
@@ -42,7 +42,7 @@ def run_dba_dye_to_host_fitting(
     h0 = h0_in_M * 1e6
 
     print(
-        f"Loaded boundaries:\nId: [{Id_lower * 1e6:.3e}, {Id_upper * 1e6:.3e}] M⁻¹\nI0: [{I0_lower:.3e}, {I0_upper:.3e}]"
+        f"Loaded boundaries:\nId: [{Id_lower * 1e6:.3e}, {Id_upper * 1e6:.3e}] M^-1\nI0: [{I0_lower:.3e}, {I0_upper:.3e}]"
     )
 
     data_lines = load_data(file_path)

--- a/core/fitting/dba_host_to_dye.py
+++ b/core/fitting/dba_host_to_dye.py
@@ -42,7 +42,7 @@ def run_dba_host_to_dye_fitting(
     d0 = d0_in_M * 1e6
 
     print(
-        f"Loaded boundaries:\nId: [{Id_lower * 1e6:.3e}, {Id_upper * 1e6:.3e}] M⁻¹\nI0: [{I0_lower:.3e}, {I0_upper:.3e}]"
+        f"Loaded boundaries:\nId: [{Id_lower * 1e6:.3e}, {Id_upper * 1e6:.3e}] M^-1\nI0: [{I0_lower:.3e}, {I0_upper:.3e}]"
     )
     data_lines = load_data(file_path)
     replicas = split_replicas(data_lines)

--- a/core/fitting/dye_alone.py
+++ b/core/fitting/dye_alone.py
@@ -198,7 +198,7 @@ class DyeAloneFittingAlgorithm(BaseFittingAlgorithm):
         ax.set_ylabel("Signal Intensity [AU]")
 
         param_text = (
-            rf"$I_d (µM⁻¹): {formatter(Id_mean)}$"
+            rf"$I_d (\mu M^{{-1}}): {formatter(Id_mean)}$"
             + "\n"
             + rf"$I_0 (AU): {formatter(I0_mean)}$"
         )
@@ -215,7 +215,7 @@ class DyeAloneFittingAlgorithm(BaseFittingAlgorithm):
         )
         with open(unique_filename(output_file_path), "w") as f:
             f.write("Linear Fit Results\n")
-            f.write(f"Average Id\t{Id_mean:.3e} (in µM⁻¹) \n")
+            f.write(f"Average Id\t{Id_mean:.3e} (in µM^-1) \n")
             f.write(
                 f"Id prediction interval (95%) at least 25% above and below average value: [{Id_lower_bound}, {Id_upper_bound}]\n"
             )

--- a/core/fitting/gda.py
+++ b/core/fitting/gda.py
@@ -40,7 +40,7 @@ def run_gda_fitting(
         load_bounds_from_results_file(results_file_path)
     )
     print(
-        f"Loaded boundaries:\nId: [{Id_lower * 1e6:.3e}, {Id_upper * 1e6:.3e}] M⁻¹\nI0: [{I0_lower:.3e}, {I0_upper:.3e}]"
+        f"Loaded boundaries:\nId: [{Id_lower * 1e6:.3e}, {Id_upper * 1e6:.3e}] M^-1\nI0: [{I0_lower:.3e}, {I0_upper:.3e}]"
     )
     Kd = Kd_in_M / 1e6
     h0 = h0_in_M * 1e6

--- a/core/fitting/ida.py
+++ b/core/fitting/ida.py
@@ -43,7 +43,7 @@ class IDAFittingAlgorithm(BaseFittingAlgorithm):
             load_bounds_from_results_file(results_file_path)
         )
         print(
-            f"Loaded boundaries:\nId: [{Id_lower * 1e6:.3e}, {Id_upper * 1e6:.3e}] M⁻¹\nI0: [{I0_lower:.3e}, {I0_upper:.3e}]"
+            f"Loaded boundaries:\nId: [{Id_lower * 1e6:.3e}, {Id_upper * 1e6:.3e}] M^-1\nI0: [{I0_lower:.3e}, {I0_upper:.3e}]"
         )
         Kd = Kd_in_M / 1e6
         h0 = h0_in_M * 1e6

--- a/core/fitting_utils.py
+++ b/core/fitting_utils.py
@@ -3,7 +3,6 @@ from datetime import datetime
 
 import numpy as np
 
-
 # Unified assay mappings consistent with load_replica_file
 assay_mappings = {
     "dba_HtoD": {
@@ -20,6 +19,7 @@ assay_mappings = {
     "gda": {"constant": "g0", "variable": "d0", "k_param": "Kg"},
 }
 
+
 def load_data(file_path):
     try:
         with open(file_path, "r") as f:
@@ -34,6 +34,8 @@ def load_data(file_path):
 
 def split_replicas(data):
     replicas, current_replica = [], []
+    # remove empty lines and strip whitespace
+    data = [line.strip() for line in data if line.strip()]
     for line in data:
         if "var" in line.lower():
             if current_replica:
@@ -47,7 +49,9 @@ def split_replicas(data):
                     current_replica = []
                 current_replica.append((x, y))
             except ValueError:
-                continue
+                raise ValueError(
+                    f"Invalid line in your input data. Line number: {data.index(line) + 1} (empty lines don't count). Line content: {line}. Please double-check your data.\n\n"
+                )
     if current_replica:
         replicas.append(np.array(current_replica))
     if not replicas:
@@ -100,8 +104,10 @@ def load_bounds_from_results_file(results_file_path):
                 average_Id = float(
                     next(line for line in lines if "Average Id" in line)
                     .split("\t")[-1]
+                    .split()[0]
                     .strip()
                 )
+                # TODO: ask frank bounds for average Id
                 Id_lower = 0.5 * average_Id
                 Id_upper = 2.0 * average_Id
             i0_prediction_line = next(
@@ -118,8 +124,10 @@ def load_bounds_from_results_file(results_file_path):
                 average_I0 = float(
                     next(line for line in lines if "Average I0" in line)
                     .split("\t")[-1]
+                    .split()[0]
                     .strip()
                 )
+                # TODO: ask frank bounds for average I0
                 I0_lower = 0.5 * average_I0
                 I0_upper = 2.0 * average_I0
         except Exception as e:

--- a/env.yml
+++ b/env.yml
@@ -1,0 +1,20 @@
+name: fitting_app
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - matplotlib
+  - numpy
+  - openpyxl
+  - scipy
+  - pandas
+  - bottleneck
+  - dask
+  - netcdf4
+  - xarray
+  - h5netcdf
+  - sphinx
+  - sphinxawesome-theme
+  - sphinx-design
+  - watchdog
+  - ipykernel

--- a/gui/interface_DBA_host_to_dye_fitting.py
+++ b/gui/interface_DBA_host_to_dye_fitting.py
@@ -38,18 +38,16 @@ class DBAFittingAppHtoD:
         self.display_plots_var.set(True)
 
         # # for testing
-        # self.fit_trials_var.set(10)
-        # self.d0_var.set(6e-6)
-        # self.file_path_var.set(
-        #     "/Users/ahmadomira/git/App Test/dba-h2d-test/DBA_system_host_to_dye.txt"
-        # )
-        # self.use_dye_alone_results.set(True)
+        self.fit_trials_var.set(10)
+        self.d0_var.set(12.7e-6)
+        self.file_path_var.set("/Users/ahmadomira/Desktop/hanna/replica_no_header.txt")
+        self.use_dye_alone_results.set(True)
         # self.save_plots_var.set(True)
         # self.save_results_var.set(True)
 
-        # self.dye_alone_results_var.set(
-        #     "/Users/ahmadomira/git/App Test/dye-alone-test/dye_alone_results.txt"
-        # )
+        self.dye_alone_results_var.set(
+            "/Users/ahmadomira/Desktop/hanna/dye_alone_single_replica.txt"
+        )
         # self.results_dir_var.set("/Users/ahmadomira/git/App Test/dba-h2d-test/")
         # self.results_save_dir_var.set("/Users/ahmadomira/git/App Test/dba-h2d-test/")
 

--- a/gui/interface_DBA_host_to_dye_fitting.py
+++ b/gui/interface_DBA_host_to_dye_fitting.py
@@ -38,16 +38,18 @@ class DBAFittingAppHtoD:
         self.display_plots_var.set(True)
 
         # # for testing
-        self.fit_trials_var.set(10)
-        self.d0_var.set(12.7e-6)
-        self.file_path_var.set("/Users/ahmadomira/Desktop/hanna/replica_no_header.txt")
-        self.use_dye_alone_results.set(True)
+        # self.fit_trials_var.set(10)
+        # self.d0_var.set(6e-6)
+        # self.file_path_var.set(
+        #     "/Users/ahmadomira/git/App Test/dba-h2d-test/DBA_system_host_to_dye.txt"
+        # )
+        # self.use_dye_alone_results.set(True)
         # self.save_plots_var.set(True)
         # self.save_results_var.set(True)
 
-        self.dye_alone_results_var.set(
-            "/Users/ahmadomira/Desktop/hanna/dye_alone_single_replica.txt"
-        )
+        # self.dye_alone_results_var.set(
+        #     "/Users/ahmadomira/git/App Test/dye-alone-test/dye_alone_results.txt"
+        # )
         # self.results_dir_var.set("/Users/ahmadomira/git/App Test/dba-h2d-test/")
         # self.results_save_dir_var.set("/Users/ahmadomira/git/App Test/dba-h2d-test/")
 

--- a/gui/interface_DyeAlone_fitting.py
+++ b/gui/interface_DyeAlone_fitting.py
@@ -24,15 +24,15 @@ class DyeAloneFittingApp:
         self.custom_plot_title_text_var = tk.StringVar()
 
         # Set default values
-        # For testing
-        self.file_path_var.set(
-            "/Users/ahmadomira/Desktop/hanna/543 nm.txt"
-        )
-        self.save_path_var.set(
-            "/Users/ahmadomira/Desktop/hanna/543 nm results.txt"
-        )
-        self.plots_dir_var.set("/Users/ahmadomira/Desktop/hanna/")
-        self.save_plots_var.set(True)
+        # # For testing
+        # self.file_path_var.set(
+        #     "/Users/ahmadomira/git/App Test/dye-alone-test/Dye_alone.txt"
+        # )
+        # self.save_path_var.set(
+        #     "/Users/ahmadomira/git/App Test/dye-alone-test/dye_alone_results.txt"
+        # )
+        # self.plots_dir_var.set("/Users/ahmadomira/git/App Test/dye-alone-test/")
+        # self.save_plots_var.set(True)
         self.display_plots_var.set(True)
 
         tk.Label(root, text="Input File:").grid(row=0, column=0, sticky=tk.W)

--- a/gui/interface_DyeAlone_fitting.py
+++ b/gui/interface_DyeAlone_fitting.py
@@ -9,7 +9,7 @@ from core.progress_window import ProgressWindow
 class DyeAloneFittingApp:
     def __init__(self, root):
         self.root = root
-        self.root.title("IDA Fitting Replica Dye Alone")
+        self.root.title("Dye Alone Fitting")
 
         # Variables
         self.file_path_var = tk.StringVar()
@@ -24,15 +24,15 @@ class DyeAloneFittingApp:
         self.custom_plot_title_text_var = tk.StringVar()
 
         # Set default values
-        # # For testing
-        # self.file_path_var.set(
-        #     "/Users/ahmadomira/git/App Test/dye-alone-test/Dye_alone.txt"
-        # )
-        # self.save_path_var.set(
-        #     "/Users/ahmadomira/git/App Test/dye-alone-test/dye_alone_results.txt"
-        # )
-        # self.plots_dir_var.set("/Users/ahmadomira/git/App Test/dye-alone-test/")
-        # self.save_plots_var.set(True)
+        # For testing
+        self.file_path_var.set(
+            "/Users/ahmadomira/Desktop/hanna/543 nm.txt"
+        )
+        self.save_path_var.set(
+            "/Users/ahmadomira/Desktop/hanna/543 nm results.txt"
+        )
+        self.plots_dir_var.set("/Users/ahmadomira/Desktop/hanna/")
+        self.save_plots_var.set(True)
         self.display_plots_var.set(True)
 
         tk.Label(root, text="Input File:").grid(row=0, column=0, sticky=tk.W)


### PR DESCRIPTION
-  remove superscript from printed units to avoid encoding issues on Windows
-  fix reading Id & I0 values from a results file when only a single dye-alone replica is present