### PR TITLE
feat(io): dispatch readers by content sniffing within an extension

### DIFF
--- a/core/io/base.py
+++ b/core/io/base.py
@@ -18,6 +18,11 @@ class MeasurementReader(Protocol):
     Implementations must define:
     - extensions: tuple of supported file extensions (e.g., ('.txt',))
     - read(path) -> pd.DataFrame
+
+    Implementations may optionally define ``can_read(path) -> bool`` as a
+    classmethod for content-based dispatch when several readers share an
+    extension (e.g., generic CSV vs. JASCO CSV vs. EnSight CSV). Readers
+    that don't implement it are treated as always-accepting fallbacks.
     """
 
     extensions: tuple[str, ...]

--- a/core/io/registry.py
+++ b/core/io/registry.py
@@ -1,50 +1,41 @@
 """Format registry for I/O dispatch.
 
-Simple dict-based registry — no decorators, no magic.
-Readers and writers register themselves on module import.
+Each extension can have one or more registered readers. When dispatching a
+file path, ``get_reader`` walks the candidates in registration order and
+returns the first one whose ``can_read(path)`` classmethod returns True.
+Readers without a ``can_read`` method are treated as always-accepting and
+serve as fallbacks (e.g., the generic ``CsvReader`` after JASCO/EnSight
+sniffers for ``.csv``).
+
+Register format-specific sniffers *before* generic fallbacks at import time.
 """
 
 from pathlib import Path
-from typing import Dict, Type
+from typing import Dict, List, Type
 
 from core.io.base import MeasurementReader, ResultWriter
 
-# Explicit registries — format implementations register on import
-READERS: Dict[str, Type[MeasurementReader]] = {}
+# Extension → ordered list of candidate readers; first matching sniffer wins.
+READERS: Dict[str, List[Type[MeasurementReader]]] = {}
 WRITERS: Dict[str, Type[ResultWriter]] = {}
 
 
 def register_reader(reader_cls: Type[MeasurementReader]) -> Type[MeasurementReader]:
     """Register a reader class for its supported extensions.
 
-    Parameters
-    ----------
-    reader_cls : Type[MeasurementReader]
-        Reader class with `extensions` attribute.
-
-    Returns
-    -------
-    Type[MeasurementReader]
-        The same class (allows use as decorator).
+    Multiple readers may share an extension; dispatch is content-sniffed via
+    each reader's ``can_read`` classmethod at lookup time. Registration order
+    is preserved — register specific sniffers before generic fallbacks.
     """
     for ext in reader_cls.extensions:
-        READERS[ext.lower()] = reader_cls
+        candidates = READERS.setdefault(ext.lower(), [])
+        if reader_cls not in candidates:
+            candidates.append(reader_cls)
     return reader_cls
 
 
 def register_writer(writer_cls: Type[ResultWriter]) -> Type[ResultWriter]:
-    """Register a writer class for its supported extensions.
-
-    Parameters
-    ----------
-    writer_cls : Type[ResultWriter]
-        Writer class with `extensions` attribute.
-
-    Returns
-    -------
-    Type[ResultWriter]
-        The same class (allows use as decorator).
-    """
+    """Register a writer class for its supported extensions."""
     for ext in writer_cls.extensions:
         WRITERS[ext.lower()] = writer_cls
     return writer_cls
@@ -53,50 +44,38 @@ def register_writer(writer_cls: Type[ResultWriter]) -> Type[ResultWriter]:
 def get_reader(path: Path) -> MeasurementReader:
     """Get a reader instance for the given file path.
 
-    Parameters
-    ----------
-    path : Path
-        File path to read.
-
-    Returns
-    -------
-    MeasurementReader
-        Reader instance for the file's extension.
+    Walks the registered candidates for the file's extension and returns
+    the first one whose ``can_read(path)`` returns True. Readers without
+    ``can_read`` are treated as always-accepting (fallback behaviour).
 
     Raises
     ------
     ValueError
-        If no reader is registered for the file extension.
+        If no reader is registered for the extension, or every candidate's
+        sniffer rejected the file.
     """
     ext = path.suffix.lower()
-    if ext not in READERS:
-        supported = list(READERS.keys())
-        raise ValueError(f"No reader for '{ext}'. Supported: {supported}")
-    return READERS[ext]()
+    candidates = READERS.get(ext)
+    if not candidates:
+        raise ValueError(f"No reader for '{ext}'. Supported: {sorted(READERS)}")
+
+    for cls in candidates:
+        sniffer = getattr(cls, "can_read", None)
+        if sniffer is None or sniffer(path):
+            return cls()
+
+    names = [cls.__name__ for cls in candidates]
+    raise ValueError(
+        f"No registered reader accepted '{path.name}'. "
+        f"Tried (in order): {names}."
+    )
 
 
 def get_writer(path: Path) -> ResultWriter:
-    """Get a writer instance for the given file path.
-
-    Parameters
-    ----------
-    path : Path
-        File path to write.
-
-    Returns
-    -------
-    ResultWriter
-        Writer instance for the file's extension.
-
-    Raises
-    ------
-    ValueError
-        If no writer is registered for the file extension.
-    """
+    """Get a writer instance for the given file path."""
     ext = path.suffix.lower()
     if ext not in WRITERS:
-        supported = list(WRITERS.keys())
-        raise ValueError(f"No writer for '{ext}'. Supported: {supported}")
+        raise ValueError(f"No writer for '{ext}'. Supported: {sorted(WRITERS)}")
     return WRITERS[ext]()
 
 

--- a/tests/unit/test_io_registry.py
+++ b/tests/unit/test_io_registry.py
@@ -1,0 +1,111 @@
+"""Tests for the content-sniffing reader registry.
+
+Covers the dispatch contract introduced when multiple readers share an
+extension (the JASCO/EnSight readers both target ``.csv`` alongside the
+generic ``CsvReader``):
+
+* registration preserves order
+* ``get_reader`` walks candidates and honours each reader's ``can_read``
+* readers without ``can_read`` are always-accepting (fallback)
+* an empty candidate list (or all sniffers rejecting) raises ``ValueError``
+
+The existing readers (TXT, XLSX, generic CSV) are still reachable through
+the new dispatcher — these tests double as a regression net.
+"""
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from core.io.registry import READERS, get_reader, register_reader
+
+
+@pytest.fixture
+def isolated_registry(monkeypatch):
+    """Snapshot READERS and restore after the test."""
+    snapshot = {ext: list(candidates) for ext, candidates in READERS.items()}
+    yield
+    READERS.clear()
+    READERS.update(snapshot)
+
+
+class _Accepter:
+    extensions = (".dummy",)
+
+    @classmethod
+    def can_read(cls, path: Path) -> bool:
+        return True
+
+    def read(self, path: Path) -> pd.DataFrame:
+        return pd.DataFrame({"concentration": [0.0], "signal": [1.0], "replica": [0]})
+
+
+class _Rejecter:
+    extensions = (".dummy",)
+
+    @classmethod
+    def can_read(cls, path: Path) -> bool:
+        return False
+
+    def read(self, path: Path) -> pd.DataFrame:
+        raise AssertionError("Rejecter.read should never be called")
+
+
+class _Fallback:
+    """No can_read → always-accepting fallback."""
+
+    extensions = (".dummy",)
+
+    def read(self, path: Path) -> pd.DataFrame:
+        return pd.DataFrame({"concentration": [0.0], "signal": [2.0], "replica": [0]})
+
+
+class TestRegistry:
+    def test_existing_extensions_still_dispatch(self, tmp_path):
+        """Default registrations (txt, csv, xlsx) survive the rewrite."""
+        p = tmp_path / "x.txt"
+        p.write_text("var\tsignal\n0.0\t100.0\n")
+        reader = get_reader(p)
+        assert type(reader).__name__ == "TxtReader"
+
+    def test_unknown_extension_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="No reader for"):
+            get_reader(tmp_path / "nope.unknownext")
+
+    def test_first_matching_sniffer_wins(self, tmp_path, isolated_registry):
+        register_reader(_Rejecter)
+        register_reader(_Accepter)
+        register_reader(_Fallback)
+        p = tmp_path / "x.dummy"
+        p.touch()
+        reader = get_reader(p)
+        assert isinstance(reader, _Accepter)
+
+    def test_no_can_read_acts_as_fallback(self, tmp_path, isolated_registry):
+        register_reader(_Rejecter)
+        register_reader(_Fallback)
+        p = tmp_path / "x.dummy"
+        p.touch()
+        reader = get_reader(p)
+        assert isinstance(reader, _Fallback)
+
+    def test_all_sniffers_reject_raises(self, tmp_path, isolated_registry):
+        register_reader(_Rejecter)
+        p = tmp_path / "x.dummy"
+        p.touch()
+        with pytest.raises(ValueError, match="No registered reader accepted"):
+            get_reader(p)
+
+    def test_register_is_idempotent(self, isolated_registry):
+        before = len(READERS.get(".dummy", []))
+        register_reader(_Accepter)
+        register_reader(_Accepter)
+        after = len(READERS.get(".dummy", []))
+        assert after == before + 1
+
+    def test_registration_order_preserved(self, isolated_registry):
+        register_reader(_Accepter)
+        register_reader(_Rejecter)
+        register_reader(_Fallback)
+        assert READERS[".dummy"] == [_Accepter, _Rejecter, _Fallback]

--- a/tests/unit/test_io_registry.py
+++ b/tests/unit/test_io_registry.py
@@ -18,6 +18,12 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
+# Importing the package (not just registry) triggers the side-effect
+# registration of the built-in readers (TxtReader, CsvReader, XlsxReader)
+# via core.io.__init__. Without this, running this module in isolation
+# (e.g. pytest tests/unit/test_io_registry.py::TestRegistry::test_existing_extensions_still_dispatch)
+# would find an empty registry and become order-dependent.
+import core.io  # noqa: F401
 from core.io.registry import READERS, get_reader, register_reader
 
 


### PR DESCRIPTION
## Summary

Foundation for the JASCO and EnSight reader PRs that will follow. Multiple readers can now register for the same file extension; dispatch is content-sniffed via an optional `can_read(path)` classmethod.

- `core/io/registry.py` — `READERS` now maps extension → ordered list of candidate reader classes. `get_reader` walks the list and returns the first whose `can_read(path)` returns True; readers without `can_read` are treated as always-accepting fallbacks. Empty match raises `ValueError`.
- `core/io/base.py` — Protocol docstring documents the new optional `can_read` contract. Existing readers (`TxtReader`, `XlsxReader`, `CsvReader`) are unchanged and behave as always-accepting fallbacks.
- `tests/unit/test_io_registry.py` — dispatch tests cover sniff order, fallback semantics, idempotent registration, and the all-reject error path.

No behavior change for any currently registered reader. This is a strict superset of the previous dispatch.

## Test plan
- [x] `pytest tests/unit/test_io_registry.py tests/unit/test_io.py tests/unit/test_io_bmg.py -v` — 33 passed, 6 skipped
- [x] Full non-GUI suite: `pytest tests/ --ignore=tests/unit/gui` — 293 passed, 6 skipped
- [ ] Wait on JASCO and EnSight reader PRs to confirm the dispatcher correctly routes the new sniffers ahead of the generic CSV fallback.

Part of the `feature/io-readers` stack — closes nothing on its own; unblocks the next two PRs.