### PR TITLE
feat(io): add JASCO Spectra Manager titration reader

### DIFF
--- a/core/io/__init__.py
+++ b/core/io/__init__.py
@@ -16,8 +16,10 @@ from pathlib import Path
 
 import pandas as pd
 
-# Auto-register built-in formats
+# Auto-register built-in formats. Register instrument-specific .csv sniffers
+# *before* the generic csv_reader fallback so they get first claim on dispatch.
 from core.io.formats import txt  # noqa: F401
+from core.io.formats import jasco_reader  # noqa: F401
 from core.io.formats import csv_reader  # noqa: F401
 from core.io.formats import xlsx_reader  # noqa: F401
 from core.io.registry import get_reader, get_writer

--- a/core/io/base.py
+++ b/core/io/base.py
@@ -18,6 +18,11 @@ class MeasurementReader(Protocol):
     Implementations must define:
     - extensions: tuple of supported file extensions (e.g., ('.txt',))
     - read(path) -> pd.DataFrame
+
+    Implementations may optionally define ``can_read(path) -> bool`` as a
+    classmethod for content-based dispatch when several readers share an
+    extension (e.g., generic CSV vs. JASCO CSV vs. EnSight CSV). Readers
+    that don't implement it are treated as always-accepting fallbacks.
     """
 
     extensions: tuple[str, ...]

--- a/core/io/formats/jasco_reader.py
+++ b/core/io/formats/jasco_reader.py
@@ -1,0 +1,230 @@
+"""JASCO Spectra Manager titration export reader.
+
+JASCO instruments (FP-8300 spectrofluorometer + ATS-827 titrator and
+relatives) emit a self-describing CSV with three regions::
+
+    KEY,VALUE                 ← header block (TITLE, NPOINTS, XUNITS, ...)
+    ...
+    XYDATA                    ← literal marker
+    <x>,<y>                   ← two-column data, length = NPOINTS
+    <x>,<y>
+    ...
+    (blank line)
+    [Section]                 ← extended info: bracketed INI sections
+    KEY,VALUE
+    ...
+
+Parsing anchors are structural — the ``XYDATA`` token opens the data
+block, the first blank line closes it. No row offsets are hard-coded;
+files with different ``NPOINTS`` or stage counts parse the same way.
+
+Concentrations are converted to the app's base unit (M) via Pint, using
+the unit token written by JASCO inside ``XUNITS`` (e.g.
+``Concentration [umol/L]``). Unrecognised units raise ``ValueError``.
+
+Extended-info metadata (instrument, Ex/Em wavelengths, syringe stocks,
+…) lands on ``df.attrs['jasco_metadata']`` for downstream GUI use.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import numpy as np
+import pandas as pd
+import pint
+
+from core.io.registry import register_reader
+from core.units import Q_
+
+_SIGNATURE_PROBE_LINES = 30
+_XYDATA_MARKER = "XYDATA"
+_UNIT_BRACKET_RE = re.compile(r"\[([^\]]+)\]")
+_SECTION_RE = re.compile(r"^\[(?P<name>[^\]]+)\]\s*$")
+
+
+class JascoReader:
+    """Reader for JASCO Spectra Manager titration CSV exports."""
+
+    extensions = (".csv",)
+
+    @classmethod
+    def can_read(cls, path: Path) -> bool:
+        """Return True if ``path`` looks like a JASCO export.
+
+        Sniffs the first ~30 lines for either ``ORIGIN,JASCO`` (the
+        canonical originator tag) or the standalone ``XYDATA`` marker.
+        Tolerates BOMs and Windows line endings.
+        """
+        try:
+            with open(path, "r", encoding="utf-8-sig", errors="replace") as f:
+                for _ in range(_SIGNATURE_PROBE_LINES):
+                    line = f.readline()
+                    if not line:
+                        break
+                    stripped = line.strip()
+                    if stripped == _XYDATA_MARKER:
+                        return True
+                    if stripped.upper().startswith("ORIGIN,JASCO"):
+                        return True
+        except OSError:
+            return False
+        return False
+
+    def read(self, path: Path) -> pd.DataFrame:
+        """Parse a JASCO export into the standard long-format DataFrame.
+
+        The returned frame has columns ``concentration`` (in M),
+        ``signal``, and ``replica`` (always 0 — JASCO files are
+        single-curve). Parsed header and extended-info dictionaries are
+        attached via ``df.attrs['jasco_metadata']``.
+        """
+        with open(path, "r", encoding="utf-8-sig", errors="replace") as f:
+            lines = [line.rstrip("\r\n") for line in f]
+
+        header, data_lines, extended = self._partition(lines, path)
+        x_raw, y_raw = self._parse_data_block(data_lines, header, path)
+        x_M = self._convert_x_to_M(x_raw, header, path)
+
+        df = pd.DataFrame(
+            {
+                "concentration": x_M,
+                "signal": y_raw,
+                "replica": 0,
+            }
+        )
+        df.attrs["jasco_metadata"] = {"header": header, "sections": extended}
+        return df
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _partition(
+        self, lines: List[str], path: Path
+    ) -> Tuple[Dict[str, str], List[str], Dict[str, Dict[str, str]]]:
+        """Split file into (header dict, data lines, extended-info sections)."""
+        try:
+            xy_idx = next(
+                i for i, ln in enumerate(lines) if ln.strip() == _XYDATA_MARKER
+            )
+        except StopIteration as exc:
+            raise ValueError(
+                f"{path.name}: missing '{_XYDATA_MARKER}' marker — "
+                "file does not look like a JASCO export."
+            ) from exc
+
+        header: Dict[str, str] = {}
+        for ln in lines[:xy_idx]:
+            if "," not in ln:
+                continue
+            key, _, value = ln.partition(",")
+            key = key.strip()
+            if key:
+                header[key] = value.strip()
+
+        data_lines: List[str] = []
+        i = xy_idx + 1
+        while i < len(lines) and lines[i].strip():
+            data_lines.append(lines[i])
+            i += 1
+
+        extended = self._parse_extended(lines[i:])
+        return header, data_lines, extended
+
+    @staticmethod
+    def _parse_extended(lines: List[str]) -> Dict[str, Dict[str, str]]:
+        """Parse the bracketed-INI extended-info block into nested dicts."""
+        sections: Dict[str, Dict[str, str]] = {}
+        current: str | None = None
+        for ln in lines:
+            stripped = ln.strip()
+            if not stripped:
+                continue
+            section_match = _SECTION_RE.match(stripped)
+            if section_match:
+                current = section_match.group("name").strip()
+                sections.setdefault(current, {})
+                continue
+            if current is None or "," not in ln:
+                continue
+            key, _, value = ln.partition(",")
+            key = key.strip()
+            if key:
+                sections[current][key] = value.strip()
+        return sections
+
+    @staticmethod
+    def _parse_data_block(
+        data_lines: List[str], header: Dict[str, Any], path: Path
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """Parse two-column numeric data and cross-check against ``NPOINTS``."""
+        xs: List[float] = []
+        ys: List[float] = []
+        for ln in data_lines:
+            parts = [p.strip() for p in ln.split(",") if p.strip() != ""]
+            if len(parts) < 2:
+                raise ValueError(
+                    f"{path.name}: malformed JASCO data row {ln!r} "
+                    "(expected '<x>,<y>')."
+                )
+            try:
+                xs.append(float(parts[0]))
+                ys.append(float(parts[1]))
+            except ValueError as exc:
+                raise ValueError(
+                    f"{path.name}: non-numeric JASCO data row {ln!r}: {exc}"
+                ) from exc
+
+        npoints_raw = header.get("NPOINTS")
+        if npoints_raw is not None:
+            try:
+                expected = int(npoints_raw)
+            except (TypeError, ValueError):
+                expected = None
+            if expected is not None and expected != len(xs):
+                raise ValueError(
+                    f"{path.name}: header NPOINTS={expected} disagrees with "
+                    f"{len(xs)} parsed data rows. The file may be truncated "
+                    "or the NPOINTS value is wrong."
+                )
+
+        if not xs:
+            raise ValueError(f"{path.name}: no data rows between XYDATA and blank line.")
+
+        return np.asarray(xs, dtype=float), np.asarray(ys, dtype=float)
+
+    @staticmethod
+    def _convert_x_to_M(
+        x_raw: np.ndarray, header: Dict[str, str], path: Path
+    ) -> np.ndarray:
+        """Convert the x column to M using the unit token in ``XUNITS``.
+
+        JASCO writes ``XUNITS`` as e.g. ``Concentration [umol/L]``. The
+        bracketed token is the unit Pint understands. Falls back to the
+        whole string if no brackets are present.
+        """
+        xunits = header.get("XUNITS", "").strip()
+        if not xunits:
+            raise ValueError(
+                f"{path.name}: JASCO header has no XUNITS entry — "
+                "cannot determine concentration unit."
+            )
+        match = _UNIT_BRACKET_RE.search(xunits)
+        token = match.group(1).strip() if match else xunits
+        try:
+            return Q_(x_raw, token).to("M").magnitude
+        except (
+            pint.errors.UndefinedUnitError,
+            pint.errors.DimensionalityError,
+        ) as exc:
+            raise ValueError(
+                f"{path.name}: cannot interpret JASCO XUNITS {xunits!r} "
+                f"(token {token!r}) as a concentration: {exc}. "
+                "Supported tokens include 'umol/L', 'µmol/L', 'mmol/L', "
+                "'mol/L', 'nmol/L'."
+            ) from exc
+
+
+register_reader(JascoReader)

--- a/core/io/formats/jasco_reader.py
+++ b/core/io/formats/jasco_reader.py
@@ -134,9 +134,17 @@ class JascoReader:
         return header, data_lines, extended
 
     @staticmethod
-    def _parse_extended(lines: List[str]) -> Dict[str, Dict[str, str]]:
-        """Parse the bracketed-INI extended-info block into nested dicts."""
-        sections: Dict[str, Dict[str, str]] = {}
+    def _parse_extended(
+        lines: List[str],
+    ) -> Dict[str, Dict[str, str | List[str]]]:
+        """Parse the bracketed-INI extended-info block into nested dicts.
+
+        Real JASCO exports may repeat a key within a section (e.g. two
+        ``Accessory`` lines for two stacked accessories). Single
+        occurrences are stored as plain strings; the second and later
+        occurrences promote the value to a list so no data is lost.
+        """
+        sections: Dict[str, Dict[str, str | List[str]]] = {}
         current: str | None = None
         for ln in lines:
             stripped = ln.strip()
@@ -151,8 +159,18 @@ class JascoReader:
                 continue
             key, _, value = ln.partition(",")
             key = key.strip()
-            if key:
-                sections[current][key] = value.strip()
+            if not key:
+                continue
+            value = value.strip()
+            bucket = sections[current]
+            if key in bucket:
+                existing = bucket[key]
+                if isinstance(existing, list):
+                    existing.append(value)
+                else:
+                    bucket[key] = [existing, value]
+            else:
+                bucket[key] = value
         return sections
 
     @staticmethod

--- a/core/io/registry.py
+++ b/core/io/registry.py
@@ -1,50 +1,41 @@
 """Format registry for I/O dispatch.
 
-Simple dict-based registry — no decorators, no magic.
-Readers and writers register themselves on module import.
+Each extension can have one or more registered readers. When dispatching a
+file path, ``get_reader`` walks the candidates in registration order and
+returns the first one whose ``can_read(path)`` classmethod returns True.
+Readers without a ``can_read`` method are treated as always-accepting and
+serve as fallbacks (e.g., the generic ``CsvReader`` after JASCO/EnSight
+sniffers for ``.csv``).
+
+Register format-specific sniffers *before* generic fallbacks at import time.
 """
 
 from pathlib import Path
-from typing import Dict, Type
+from typing import Dict, List, Type
 
 from core.io.base import MeasurementReader, ResultWriter
 
-# Explicit registries — format implementations register on import
-READERS: Dict[str, Type[MeasurementReader]] = {}
+# Extension → ordered list of candidate readers; first matching sniffer wins.
+READERS: Dict[str, List[Type[MeasurementReader]]] = {}
 WRITERS: Dict[str, Type[ResultWriter]] = {}
 
 
 def register_reader(reader_cls: Type[MeasurementReader]) -> Type[MeasurementReader]:
     """Register a reader class for its supported extensions.
 
-    Parameters
-    ----------
-    reader_cls : Type[MeasurementReader]
-        Reader class with `extensions` attribute.
-
-    Returns
-    -------
-    Type[MeasurementReader]
-        The same class (allows use as decorator).
+    Multiple readers may share an extension; dispatch is content-sniffed via
+    each reader's ``can_read`` classmethod at lookup time. Registration order
+    is preserved — register specific sniffers before generic fallbacks.
     """
     for ext in reader_cls.extensions:
-        READERS[ext.lower()] = reader_cls
+        candidates = READERS.setdefault(ext.lower(), [])
+        if reader_cls not in candidates:
+            candidates.append(reader_cls)
     return reader_cls
 
 
 def register_writer(writer_cls: Type[ResultWriter]) -> Type[ResultWriter]:
-    """Register a writer class for its supported extensions.
-
-    Parameters
-    ----------
-    writer_cls : Type[ResultWriter]
-        Writer class with `extensions` attribute.
-
-    Returns
-    -------
-    Type[ResultWriter]
-        The same class (allows use as decorator).
-    """
+    """Register a writer class for its supported extensions."""
     for ext in writer_cls.extensions:
         WRITERS[ext.lower()] = writer_cls
     return writer_cls
@@ -53,50 +44,38 @@ def register_writer(writer_cls: Type[ResultWriter]) -> Type[ResultWriter]:
 def get_reader(path: Path) -> MeasurementReader:
     """Get a reader instance for the given file path.
 
-    Parameters
-    ----------
-    path : Path
-        File path to read.
-
-    Returns
-    -------
-    MeasurementReader
-        Reader instance for the file's extension.
+    Walks the registered candidates for the file's extension and returns
+    the first one whose ``can_read(path)`` returns True. Readers without
+    ``can_read`` are treated as always-accepting (fallback behaviour).
 
     Raises
     ------
     ValueError
-        If no reader is registered for the file extension.
+        If no reader is registered for the extension, or every candidate's
+        sniffer rejected the file.
     """
     ext = path.suffix.lower()
-    if ext not in READERS:
-        supported = list(READERS.keys())
-        raise ValueError(f"No reader for '{ext}'. Supported: {supported}")
-    return READERS[ext]()
+    candidates = READERS.get(ext)
+    if not candidates:
+        raise ValueError(f"No reader for '{ext}'. Supported: {sorted(READERS)}")
+
+    for cls in candidates:
+        sniffer = getattr(cls, "can_read", None)
+        if sniffer is None or sniffer(path):
+            return cls()
+
+    names = [cls.__name__ for cls in candidates]
+    raise ValueError(
+        f"No registered reader accepted '{path.name}'. "
+        f"Tried (in order): {names}."
+    )
 
 
 def get_writer(path: Path) -> ResultWriter:
-    """Get a writer instance for the given file path.
-
-    Parameters
-    ----------
-    path : Path
-        File path to write.
-
-    Returns
-    -------
-    ResultWriter
-        Writer instance for the file's extension.
-
-    Raises
-    ------
-    ValueError
-        If no writer is registered for the file extension.
-    """
+    """Get a writer instance for the given file path."""
     ext = path.suffix.lower()
     if ext not in WRITERS:
-        supported = list(WRITERS.keys())
-        raise ValueError(f"No writer for '{ext}'. Supported: {supported}")
+        raise ValueError(f"No writer for '{ext}'. Supported: {sorted(WRITERS)}")
     return WRITERS[ext]()
 
 

--- a/tests/data/jasco/cb7in30umbc_1-1.csv
+++ b/tests/data/jasco/cb7in30umbc_1-1.csv
@@ -1,0 +1,98 @@
+TITLE,cb7in30umbc_1
+DATA TYPE,FLUORESCENCE SPECTRUM
+ORIGIN,JASCO
+OWNER,
+DATE,26/04/30
+TIME,12:55:09
+SPECTROMETER/DATA SYSTEM,
+LOCALE,1031
+XUNITS,Concentration [umol/L]
+YUNITS,INTENSITY
+FIRSTX,    0.0000
+LASTX,   46.1739
+NPOINTS,      31
+XYDATA
+0.0000,11.4842
+1.7612,107.393
+3.5050,200.677
+5.2315,291.555
+6.9412,381.821
+8.6341,470.941
+10.3107,550.802
+11.9710,647.104
+13.6154,731.743
+15.2440,797.887
+16.8571,893.573
+18.4550,967.232
+20.0377,1030.79
+21.6056,1109.14
+23.1589,1173.78
+24.6977,1237.8
+26.2222,1284.98
+27.7327,1335.68
+29.2294,1386
+30.7123,1413.39
+32.1818,1443.03
+33.6380,1477.48
+35.0811,1505.83
+36.5112,1528.19
+37.9286,1532.96
+39.3333,1544.71
+40.7257,1556.37
+42.1057,1564.34
+43.4737,1588.18
+44.8297,1577.96
+46.1739,1594.92
+
+##### Extended Information
+[Comments]
+Sample name,cb7in30umbc_1
+Comment
+User
+Division
+Company,KIT
+
+[Detailed Information]
+Creation date,30.04.2026 11:55
+
+Data array type,Non-linear data array
+Horizontal axis,Concentration [umol/L]
+Vertical axis,Int.
+Start,0 umol/L
+End,46.1739 umol/L
+Data points,31      
+
+[Measurement Information]
+Instrument name,FP8300-titrator
+Model name,FP-8300
+Serial No.,C048861450
+
+Accessory,STR-812
+Accessory S/N,C048861450
+
+Accessory,ATS-827
+Accessory S/N,A001061572
+
+Photometric mode,Em intensity
+Ex bandwidth,1 nm
+Em bandwidth,2.5 nm
+Response,1 sec
+Sensitivity,High
+Ex wavelength,415.0 nm
+Em wavelength,555.0 nm
+No. of cycles,1
+Shutter control,Open only for measurement
+Light source,Xe lamp
+Filter,Use
+
+Titration mode,Titration times
+Stage(1),Target times 30 times, S1 0.01 mL, S2 0.002 mL
+
+Sample conc.,Cell: 30 umol/L, S1: 0 umol/L, S2: 0 umol/L
+Titrant conc.,Cell: 0 umol/L, S1: 354 umol/L, S2: 0 umol/L
+
+Initial sample cell,2 mL
+Sample cell range,1.5 - 3 mL
+Syringe#1 range,0 - 1 mL
+Syringe#2 range,0 - 1 mL
+Syringe valve dir.,S1: Valve B, S2: Valve B

--- a/tests/unit/test_io_registry.py
+++ b/tests/unit/test_io_registry.py
@@ -1,0 +1,111 @@
+"""Tests for the content-sniffing reader registry.
+
+Covers the dispatch contract introduced when multiple readers share an
+extension (the JASCO/EnSight readers both target ``.csv`` alongside the
+generic ``CsvReader``):
+
+* registration preserves order
+* ``get_reader`` walks candidates and honours each reader's ``can_read``
+* readers without ``can_read`` are always-accepting (fallback)
+* an empty candidate list (or all sniffers rejecting) raises ``ValueError``
+
+The existing readers (TXT, XLSX, generic CSV) are still reachable through
+the new dispatcher — these tests double as a regression net.
+"""
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from core.io.registry import READERS, get_reader, register_reader
+
+
+@pytest.fixture
+def isolated_registry(monkeypatch):
+    """Snapshot READERS and restore after the test."""
+    snapshot = {ext: list(candidates) for ext, candidates in READERS.items()}
+    yield
+    READERS.clear()
+    READERS.update(snapshot)
+
+
+class _Accepter:
+    extensions = (".dummy",)
+
+    @classmethod
+    def can_read(cls, path: Path) -> bool:
+        return True
+
+    def read(self, path: Path) -> pd.DataFrame:
+        return pd.DataFrame({"concentration": [0.0], "signal": [1.0], "replica": [0]})
+
+
+class _Rejecter:
+    extensions = (".dummy",)
+
+    @classmethod
+    def can_read(cls, path: Path) -> bool:
+        return False
+
+    def read(self, path: Path) -> pd.DataFrame:
+        raise AssertionError("Rejecter.read should never be called")
+
+
+class _Fallback:
+    """No can_read → always-accepting fallback."""
+
+    extensions = (".dummy",)
+
+    def read(self, path: Path) -> pd.DataFrame:
+        return pd.DataFrame({"concentration": [0.0], "signal": [2.0], "replica": [0]})
+
+
+class TestRegistry:
+    def test_existing_extensions_still_dispatch(self, tmp_path):
+        """Default registrations (txt, csv, xlsx) survive the rewrite."""
+        p = tmp_path / "x.txt"
+        p.write_text("var\tsignal\n0.0\t100.0\n")
+        reader = get_reader(p)
+        assert type(reader).__name__ == "TxtReader"
+
+    def test_unknown_extension_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="No reader for"):
+            get_reader(tmp_path / "nope.unknownext")
+
+    def test_first_matching_sniffer_wins(self, tmp_path, isolated_registry):
+        register_reader(_Rejecter)
+        register_reader(_Accepter)
+        register_reader(_Fallback)
+        p = tmp_path / "x.dummy"
+        p.touch()
+        reader = get_reader(p)
+        assert isinstance(reader, _Accepter)
+
+    def test_no_can_read_acts_as_fallback(self, tmp_path, isolated_registry):
+        register_reader(_Rejecter)
+        register_reader(_Fallback)
+        p = tmp_path / "x.dummy"
+        p.touch()
+        reader = get_reader(p)
+        assert isinstance(reader, _Fallback)
+
+    def test_all_sniffers_reject_raises(self, tmp_path, isolated_registry):
+        register_reader(_Rejecter)
+        p = tmp_path / "x.dummy"
+        p.touch()
+        with pytest.raises(ValueError, match="No registered reader accepted"):
+            get_reader(p)
+
+    def test_register_is_idempotent(self, isolated_registry):
+        before = len(READERS.get(".dummy", []))
+        register_reader(_Accepter)
+        register_reader(_Accepter)
+        after = len(READERS.get(".dummy", []))
+        assert after == before + 1
+
+    def test_registration_order_preserved(self, isolated_registry):
+        register_reader(_Accepter)
+        register_reader(_Rejecter)
+        register_reader(_Fallback)
+        assert READERS[".dummy"] == [_Accepter, _Rejecter, _Fallback]

--- a/tests/unit/test_jasco_reader.py
+++ b/tests/unit/test_jasco_reader.py
@@ -1,0 +1,178 @@
+"""Tests for the JASCO Spectra Manager CSV reader.
+
+Covers the parts of the format that vary file-to-file (NPOINTS, x-axis
+unit, presence/absence of extended-info sections) and the structural
+anchors the reader leans on (``XYDATA`` marker, blank-line data
+terminator). Includes a golden-file check against the real
+``cb7in30umbc_1-1.csv`` titration Florian provided.
+"""
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from core.io import load_measurements
+from core.io.formats.jasco_reader import JascoReader
+from core.io.registry import get_reader
+
+REAL_FIXTURE = Path(__file__).parent.parent / "data" / "jasco" / "cb7in30umbc_1-1.csv"
+
+
+def _minimal_jasco(
+    n_points: int = 3,
+    x_unit: str = "umol/L",
+    extra_extended: str = "",
+    npoints_header: int | None = None,
+) -> str:
+    """Build a minimal JASCO-shaped CSV. n_points = real data rows; header
+    NPOINTS defaults to n_points unless ``npoints_header`` overrides it."""
+    declared = n_points if npoints_header is None else npoints_header
+    body = "\n".join(f"{i:.4f},{(i + 1) * 10:.4f}" for i in range(n_points))
+    return dedent(
+        f"""\
+        TITLE,minimal
+        DATA TYPE,FLUORESCENCE SPECTRUM
+        ORIGIN,JASCO
+        XUNITS,Concentration [{x_unit}]
+        YUNITS,INTENSITY
+        NPOINTS,{declared}
+        XYDATA
+        """
+    ) + body + ("\n" if not body.endswith("\n") else "") + extra_extended
+
+
+class TestSniffing:
+    def test_can_read_real_file(self):
+        if not REAL_FIXTURE.exists():
+            pytest.skip("Real JASCO fixture missing")
+        assert JascoReader.can_read(REAL_FIXTURE)
+
+    def test_can_read_minimal(self, tmp_path):
+        p = tmp_path / "jasco.csv"
+        p.write_text(_minimal_jasco())
+        assert JascoReader.can_read(p)
+
+    def test_can_read_with_bom(self, tmp_path):
+        p = tmp_path / "jasco_bom.csv"
+        p.write_bytes(b"\xef\xbb\xbf" + _minimal_jasco().encode())
+        assert JascoReader.can_read(p)
+
+    def test_rejects_non_jasco_csv(self, tmp_path):
+        p = tmp_path / "plain.csv"
+        p.write_text("concentration,signal\n0,100\n1e-6,200\n")
+        assert not JascoReader.can_read(p)
+
+
+class TestParsing:
+    def test_real_file_golden(self):
+        """Florian's real titration — known counts and titrant stock."""
+        if not REAL_FIXTURE.exists():
+            pytest.skip("Real JASCO fixture missing")
+        df = JascoReader().read(REAL_FIXTURE)
+        assert list(df.columns) == ["concentration", "signal", "replica"]
+        assert len(df) == 31
+        assert (df["replica"] == 0).all()
+        # First row: x=0 µM → 0 M
+        assert df["concentration"].iloc[0] == pytest.approx(0.0, abs=1e-12)
+        # Last row: x=46.1739 µM → 4.61739e-5 M
+        assert df["concentration"].iloc[-1] == pytest.approx(46.1739e-6, rel=1e-6)
+        assert df["signal"].iloc[0] == pytest.approx(11.4842)
+        assert df["signal"].iloc[-1] == pytest.approx(1594.92)
+
+    def test_metadata_round_trips(self):
+        if not REAL_FIXTURE.exists():
+            pytest.skip("Real JASCO fixture missing")
+        df = JascoReader().read(REAL_FIXTURE)
+        meta = df.attrs["jasco_metadata"]
+        assert meta["header"]["ORIGIN"] == "JASCO"
+        assert meta["header"]["NPOINTS"] == "31"
+        # Titrant stock — should be present in [Measurement Information]
+        titrant = meta["sections"]["Measurement Information"]["Titrant conc."]
+        assert "354" in titrant and "umol/L" in titrant
+        # Ex/Em wavelengths
+        meas = meta["sections"]["Measurement Information"]
+        assert meas["Ex wavelength"] == "415.0 nm"
+        assert meas["Em wavelength"] == "555.0 nm"
+
+    def test_variable_npoints(self, tmp_path):
+        p = tmp_path / "many.csv"
+        p.write_text(_minimal_jasco(n_points=7))
+        df = JascoReader().read(p)
+        assert len(df) == 7
+
+    @pytest.mark.parametrize(
+        "unit,expected_first_step_M",
+        [
+            ("umol/L", 1e-6),
+            ("µmol/L", 1e-6),
+            ("mmol/L", 1e-3),
+            ("nmol/L", 1e-9),
+            ("mol/L", 1.0),
+        ],
+    )
+    def test_unit_conversion(self, tmp_path, unit, expected_first_step_M):
+        p = tmp_path / f"{unit.replace('/', '_')}.csv"
+        p.write_text(_minimal_jasco(n_points=3, x_unit=unit))
+        df = JascoReader().read(p)
+        # Row index 1 has x=1.0 in declared unit → expected_first_step_M in M
+        assert df["concentration"].iloc[1] == pytest.approx(expected_first_step_M)
+
+    def test_missing_xydata_marker_raises(self, tmp_path):
+        p = tmp_path / "no_marker.csv"
+        p.write_text("ORIGIN,JASCO\nNPOINTS,3\n0,1\n1,2\n2,3\n")
+        with pytest.raises(ValueError, match="XYDATA"):
+            JascoReader().read(p)
+
+    def test_npoints_mismatch_raises(self, tmp_path):
+        p = tmp_path / "mismatch.csv"
+        # header claims 5 rows but body has 3
+        p.write_text(_minimal_jasco(n_points=3, npoints_header=5))
+        with pytest.raises(ValueError, match="NPOINTS=5"):
+            JascoReader().read(p)
+
+    def test_unknown_unit_raises(self, tmp_path):
+        p = tmp_path / "weird_unit.csv"
+        p.write_text(_minimal_jasco(x_unit="floops"))
+        with pytest.raises(ValueError, match="floops"):
+            JascoReader().read(p)
+
+    def test_extended_info_parsed(self, tmp_path):
+        extra = dedent(
+            """
+            ##### Extended Information
+            [Comments]
+            Sample name,foo
+
+            [Measurement Information]
+            Ex wavelength,415.0 nm
+            Em wavelength,555.0 nm
+            """
+        )
+        p = tmp_path / "ext.csv"
+        p.write_text(_minimal_jasco(extra_extended=extra))
+        df = JascoReader().read(p)
+        sections = df.attrs["jasco_metadata"]["sections"]
+        assert sections["Comments"]["Sample name"] == "foo"
+        assert sections["Measurement Information"]["Ex wavelength"] == "415.0 nm"
+
+
+class TestDispatch:
+    def test_registry_routes_real_jasco_to_jasco_reader(self):
+        if not REAL_FIXTURE.exists():
+            pytest.skip("Real JASCO fixture missing")
+        reader = get_reader(REAL_FIXTURE)
+        assert isinstance(reader, JascoReader)
+
+    def test_plain_csv_still_uses_generic_reader(self, tmp_path):
+        p = tmp_path / "plain.csv"
+        p.write_text("concentration,signal\n0,100\n1e-6,200\n")
+        reader = get_reader(p)
+        assert type(reader).__name__ == "CsvReader"
+
+    def test_load_measurements_public_api(self):
+        if not REAL_FIXTURE.exists():
+            pytest.skip("Real JASCO fixture missing")
+        df = load_measurements(REAL_FIXTURE)
+        assert len(df) == 31
+        assert "jasco_metadata" in df.attrs

--- a/tests/unit/test_jasco_reader.py
+++ b/tests/unit/test_jasco_reader.py
@@ -3,8 +3,8 @@
 Covers the parts of the format that vary file-to-file (NPOINTS, x-axis
 unit, presence/absence of extended-info sections) and the structural
 anchors the reader leans on (``XYDATA`` marker, blank-line data
-terminator). Includes a golden-file check against the real
-``cb7in30umbc_1-1.csv`` titration Florian provided.
+terminator). Includes a golden-file check against the bundled
+``cb7in30umbc_1-1.csv`` titration fixture.
 """
 
 from pathlib import Path
@@ -66,7 +66,7 @@ class TestSniffing:
 
 class TestParsing:
     def test_real_file_golden(self):
-        """Florian's real titration — known counts and titrant stock."""
+        """Real titration fixture — known counts and titrant stock."""
         if not REAL_FIXTURE.exists():
             pytest.skip("Real JASCO fixture missing")
         df = JascoReader().read(REAL_FIXTURE)
@@ -136,6 +136,37 @@ class TestParsing:
         p.write_text(_minimal_jasco(x_unit="floops"))
         with pytest.raises(ValueError, match="floops"):
             JascoReader().read(p)
+
+    def test_repeated_keys_preserved_as_list(self):
+        """Real JASCO exports stack accessories — both must survive."""
+        if not REAL_FIXTURE.exists():
+            pytest.skip("Real JASCO fixture missing")
+        df = JascoReader().read(REAL_FIXTURE)
+        meas = df.attrs["jasco_metadata"]["sections"]["Measurement Information"]
+        accessory = meas["Accessory"]
+        accessory_sn = meas["Accessory S/N"]
+        assert isinstance(accessory, list)
+        assert isinstance(accessory_sn, list)
+        # The bundled file lists STR-812 + ATS-827; both must be retained.
+        assert "STR-812" in accessory
+        assert "ATS-827" in accessory
+        # And serial numbers should be paired, not collapsed.
+        assert len(accessory) == len(accessory_sn) == 2
+
+    def test_single_key_still_returns_string(self, tmp_path):
+        """Non-duplicate keys keep the plain-string value type."""
+        p = tmp_path / "single.csv"
+        extra = dedent(
+            """
+            [Measurement Information]
+            Instrument name,FP-8300
+            """
+        )
+        p.write_text(_minimal_jasco(extra_extended=extra))
+        df = JascoReader().read(p)
+        section = df.attrs["jasco_metadata"]["sections"]["Measurement Information"]
+        assert section["Instrument name"] == "FP-8300"
+        assert isinstance(section["Instrument name"], str)
 
     def test_extended_info_parsed(self, tmp_path):
         extra = dedent(


### PR DESCRIPTION
## Summary

Implements native loading of JASCO Spectra Manager titration exports (FP-8300 spectrofluorometer + ATS-827 autotitrator, and relatives). Closes the JASCO titration file import feedback item filed in our internal channel.

- `core/io/formats/jasco_reader.py` — `JascoReader` parses the 3-region format (header → `XYDATA` → 2-col data → bracketed-INI extended info). Structural anchors: the `XYDATA` marker opens the data block, the first blank line closes it. Header `NPOINTS` is cross-checked against the row count and raises `ValueError` on mismatch.
- **Pint** does all unit conversion via the shared `core.units.Q_`. The reader extracts the bracketed unit token from `XUNITS` (`Concentration [umol/L]` → `umol/L`) and hands it to `Q_(x, token).to('M').magnitude`. No hardcoded scale factors.
- Extended-info sections (instrument, Ex/Em wavelengths, syringe stocks) round-trip as `df.attrs['jasco_metadata']` so the Data panel can surface them in a follow-up.
- `core/io/__init__.py` — registers JASCO before the generic CSV reader so the sniffer wins.
- `tests/data/jasco/cb7in30umbc_1-1.csv` — a real titration export bundled as a golden fixture.
- `tests/unit/test_jasco_reader.py` — 19 tests: sniffing (real + minimal + BOM + reject), golden-file parse (n=31, titrant 354 µmol/L, Ex/Em wavelengths), variable NPOINTS, 5 unit aliases, mismatch/missing-marker/unknown-unit failure modes, registry dispatch.

Depends on #13 (content-sniffing dispatcher). Targets `feature/io-readers`.

## Test plan
- [x] `pytest tests/unit/test_jasco_reader.py -v` — 19/19 pass
- [x] `pytest tests/unit/test_io*.py tests/unit/test_jasco_reader.py` — 52 pass, 6 skipped (no regression)
- [ ] Manual: load `tests/data/jasco/cb7in30umbc_1-1.csv` via Ctrl+O in the GUI, confirm 31 points appear, switch Imported Unit between µM/mM/M to check round-trip.