### PR TITLE
GUI polish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ If architecture is flawed, state is duplicated, or patterns are inconsistent —
 
 ### Enum-Keyed Registry Pattern (central design)
 
-All assay types are registered in `core/assays/registry.py` via `ASSAY_REGISTRY: dict[AssayType, AssayMetadata]`. The `AssayType` enum drives dispatch throughout — **no isinstance checks**. Each `AssayMetadata` defines parameter keys, default bounds, log-scale keys, units, and labels.
+All assay types are registered in `core/assays/registry.py` via `ASSAY_REGISTRY: dict[AssayType, AssayMetadata]`. The `AssayType` enum drives dispatch throughout — **no isinstance checks**. Each `AssayMetadata` defines parameter keys, default bounds, log-scale keys, units, labels, and the `category` + `subtype_label` strings that drive the GUI's two-level (category → subtype) assay selector.
 
 ### Module Layers
 
@@ -126,7 +126,7 @@ Tests verify **scientific correctness first** — reproduce a bug as a failing t
 
 1. Add an enum value to `AssayType` in `core/assays/registry.py`.
 2. Create a `BaseAssay` subclass with a `forward_model()` implementation.
-3. Add an `ASSAY_REGISTRY` entry with metadata (keys, bounds, log-scale, units, labels).
+3. Add an `ASSAY_REGISTRY` entry with metadata (keys, bounds, log-scale, units, labels, and `category` + `subtype_label` — the latter two slot it into the two-level assay menu; no widget code changes needed).
 4. Add the forward-model math in `core/models/`.
 5. Add tests (parameter recovery + fail-fast).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Guidance for Claude Code when working in this repository.
 
-## graphify
+## graphify (NON-NEGOTIABLE)
 
 This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
 

--- a/core/assays/registry.py
+++ b/core/assays/registry.py
@@ -70,6 +70,15 @@ class AssayMetadata:
         Default name portion of the y-axis label (e.g. ``"Signal"``).
         The unit suffix is appended at render time by ``PlotWidget`` from
         ``y_unit``.
+    category : str
+        Top-level grouping label for the GUI assay-type selector
+        (e.g. ``"Direct Binding"``).  Assays sharing a ``category`` populate
+        the same main-dropdown group; the panel derives the two-level menu
+        from these strings, so re-grouping is a data-only change.
+    subtype_label : str
+        Short label shown in the dependent subtype dropdown
+        (e.g. ``"Host → Dye (1:1)"``).  Distinct from ``display_name``, which
+        stays the long descriptive name used for the window title.
     y_unit : str
         Unit string appended to the y-axis label (e.g. ``"a.u."``).
     default_bounds : Dict[str, Tuple[float, float]]
@@ -91,6 +100,8 @@ class AssayMetadata:
     parameter_keys: Tuple[str, ...]
     x_label: str
     y_label: str
+    category: str
+    subtype_label: str
     default_bounds: Dict[str, Tuple[Quantity, Quantity]] = field(default_factory=dict)
     log_scale_keys: Tuple[str, ...] = ()
     y_unit: str = 'a.u.'
@@ -105,6 +116,8 @@ class AssayMetadata:
 ASSAY_REGISTRY: Dict[AssayType, AssayMetadata] = {
     AssayType.GDA: AssayMetadata(
         display_name='GDA (Guest Displacement Assay)',
+        category='Competitive Displacement',
+        subtype_label='GDA — Guest Displacement (1:1)',
         parameter_keys=('Ka_guest', 'I0', 'I_dye_free', 'I_dye_bound'),
         x_label='Dye',
         y_label='Signal',
@@ -118,6 +131,8 @@ ASSAY_REGISTRY: Dict[AssayType, AssayMetadata] = {
     ),
     AssayType.IDA: AssayMetadata(
         display_name='IDA (Indicator Displacement Assay)',
+        category='Competitive Displacement',
+        subtype_label='IDA — Indicator Displacement (1:1)',
         parameter_keys=('Ka_guest', 'I0', 'I_dye_free', 'I_dye_bound'),
         x_label='Guest',
         y_label='Signal',
@@ -131,6 +146,8 @@ ASSAY_REGISTRY: Dict[AssayType, AssayMetadata] = {
     ),
     AssayType.DBA_HtoD: AssayMetadata(
         display_name='DBA Host→Dye (Direct Binding Assay)',
+        category='Direct Binding',
+        subtype_label='Host → Dye (1:1)',
         parameter_keys=('Ka_dye', 'I0', 'I_dye_free', 'I_dye_bound'),
         x_label='Host',
         y_label='Signal',
@@ -144,6 +161,8 @@ ASSAY_REGISTRY: Dict[AssayType, AssayMetadata] = {
     ),
     AssayType.DBA_DtoH: AssayMetadata(
         display_name='DBA Dye→Host (Direct Binding Assay)',
+        category='Direct Binding',
+        subtype_label='Dye → Host (1:1)',
         parameter_keys=('Ka_dye', 'I0', 'I_dye_free', 'I_dye_bound'),
         x_label='Dye',
         y_label='Signal',
@@ -157,6 +176,8 @@ ASSAY_REGISTRY: Dict[AssayType, AssayMetadata] = {
     ),
     AssayType.DYE_ALONE: AssayMetadata(
         display_name='Dye Alone (Linear Calibration)',
+        category='Calibration',
+        subtype_label='Dye Alone',
         parameter_keys=('slope', 'intercept'),
         x_label='Dye',
         y_label='Signal',
@@ -168,6 +189,8 @@ ASSAY_REGISTRY: Dict[AssayType, AssayMetadata] = {
     ),
     AssayType.DBA_HG2: AssayMetadata(
         display_name='DBA 1:2 (HG2, stepwise host–guest)',
+        category='Direct Binding',
+        subtype_label='Host–Guest 1:2 (HG₂)',
         parameter_keys=('Ka_HG', 'Ka_HG2', 'I0', 'I_G', 'I_H', 'I_HG', 'I_HG2'),
         x_label='Guest',
         y_label='Signal',
@@ -186,6 +209,8 @@ ASSAY_REGISTRY: Dict[AssayType, AssayMetadata] = {
     ),
     AssayType.DBA_H2G: AssayMetadata(
         display_name='DBA 2:1 (H2G, stepwise host–guest)',
+        category='Direct Binding',
+        subtype_label='Host–Guest 2:1 (H₂G)',
         parameter_keys=('Ka_HG', 'Ka_H2G', 'I0', 'I_G', 'I_H', 'I_HG', 'I_H2G'),
         x_label='Guest',
         y_label='Signal',

--- a/gui/fitting_session.py
+++ b/gui/fitting_session.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import replace
 from pathlib import Path
 
-from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtCore import QSize, Qt, pyqtSignal
 from PyQt6.QtWidgets import (
     QDialog,
     QFileDialog,
@@ -38,6 +38,42 @@ from gui.widgets.info_button import InfoGroupBox
 from gui.widgets.preprocessing_panel import PreprocessingPanel
 from gui.widgets.replica_panel import ReplicaPanel
 from gui.workers import FitWorker
+
+
+class _SidebarScrollArea(QScrollArea):
+    """Vertically-scrolling sidebar whose width follows its content.
+
+    A plain ``QScrollArea`` reports a near-zero width hint regardless of its
+    content, so a ``QSplitter`` will shrink it until the content clips. The
+    sidebar scrolls vertically only, so its width must track the content: we
+    advertise the content's *minimum* width (plus the frame and the vertical
+    scrollbar) as both our minimum and preferred width. The splitter then honors
+    it as the sidebar's floor and shrinks the *other* pane instead — content is
+    never clipped — while the sidebar opens compact (the content minimum) rather
+    than at the widest panel's much larger preferred width.
+    """
+
+    def _content_width(self) -> int:
+        # Width needed to show the content un-clipped: the content's own minimum
+        # width + the frame + the vertical scrollbar. Read from Qt at runtime so
+        # it adapts to platform/style and to the panels' current contents.
+        content = self.widget()
+        if content is None:
+            return 0
+        return content.minimumSizeHint().width() + 2 * self.frameWidth() + self.verticalScrollBar().sizeHint().width()
+
+    def minimumSizeHint(self) -> QSize:
+        hint = super().minimumSizeHint()
+        if self.widget() is not None:
+            hint.setWidth(self._content_width())
+        return hint
+
+    def sizeHint(self) -> QSize:
+        hint = super().sizeHint()
+        if self.widget() is not None:
+            hint.setWidth(self._content_width())
+        return hint
+
 
 _PLOT_STYLE_HELP_HTML = """
 <h3>Plot Style</h3>
@@ -509,15 +545,13 @@ class FittingSession(QWidget):
         outer.addWidget(splitter)
 
         # ---- Left panel (scrollable) --------------------------------
-        # The sidebar is freely resizable via the splitter — no maximum-width
-        # cap (a cap would crop wide content like long filenames/channel
-        # labels and prevent the user from widening). A minimum floor keeps it
-        # usable; childrenCollapsible(False) prevents collapse to zero. It
-        # scrolls vertically only — never horizontally — so content fits the
-        # current width and elides rather than overflowing sideways.
-        self._sidebar_scroll = QScrollArea()
+        # The sidebar scrolls vertically only; its width is driven by the
+        # content's own size hints (see _SidebarScrollArea). The splitter honors
+        # that as the sidebar's minimum and shrinks the plot pane instead, so the
+        # content is never clipped. No max-width cap and childrenCollapsible(False)
+        # keep it freely widenable yet never collapsible to zero.
+        self._sidebar_scroll = _SidebarScrollArea()
         self._sidebar_scroll.setWidgetResizable(True)
-        self._sidebar_scroll.setMinimumWidth(300)
         self._sidebar_scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         left_scroll = self._sidebar_scroll
 
@@ -582,15 +616,14 @@ class FittingSession(QWidget):
 
         right_splitter.addWidget(plot_area)
         right_splitter.addWidget(self._summary_widget)
-        right_splitter.setStretchFactor(0, 3)
+        right_splitter.setStretchFactor(0, 1)
         right_splitter.setStretchFactor(1, 1)
         splitter.addWidget(right_splitter)
 
         splitter.setStretchFactor(0, 0)
         splitter.setStretchFactor(1, 1)
-        # Initial split only — the user can drag freely afterwards. The
-        # sidebar opens at a comfortable width; the plot takes the rest.
-        splitter.setSizes([340, 940])
+        # No explicit initial split: the sidebar opens at its content-driven
+        # sizeHint width and the plot (stretch factor 1) takes the rest.
 
         # Initialise BoundsPanel for default assay type
         self._bounds_panel.set_assay_type(self._state.assay_type)

--- a/gui/fitting_session.py
+++ b/gui/fitting_session.py
@@ -129,7 +129,8 @@ class FittingSession(QWidget):
     Signals
     -------
     title_changed(str)
-        Emitted when the tab title should change (e.g. after assay type switch).
+        Emitted when the tab title should change — the loaded dataset's filename,
+        a user-set custom name, or "Untitled".
     status_message(str)
         Emitted to update the main window's status bar.
     """
@@ -141,12 +142,28 @@ class FittingSession(QWidget):
         super().__init__(parent)
         self._state = SessionState()
         self._fit_worker: FitWorker | None = None
+        self._custom_tab_name: str | None = None
         self._setup_ui()
         self._connect_signals()
 
     # ------------------------------------------------------------------
     # Public API (called by FittingMainWindow)
     # ------------------------------------------------------------------
+
+    def set_custom_tab_name(self, name: str) -> None:
+        """Set a manual tab name (double-click rename); empty reverts to auto."""
+        self._custom_tab_name = name.strip() or None
+        self._emit_tab_title()
+
+    def _tab_title(self) -> str:
+        """Resolve the tab title: custom name, else dataset stem, else 'Untitled'."""
+        if self._custom_tab_name:
+            return self._custom_tab_name
+        src = self._state.source_file
+        return Path(src).stem if src else 'Untitled'
+
+    def _emit_tab_title(self) -> None:
+        self.title_changed.emit(self._tab_title())
 
     def run_fit(self) -> None:
         """Start a background fitting run."""
@@ -650,6 +667,7 @@ class FittingSession(QWidget):
     def _on_data_loaded(self, ms: MeasurementSet) -> None:
         self._state.measurement_set = ms
         self._state.source_file = self._data_panel.current_path()
+        self._emit_tab_title()
         self._state.fit_results.clear()
         self._preprocess_panel.set_measurement_set(ms)
         self._replica_panel.set_measurement_set(ms)
@@ -663,6 +681,7 @@ class FittingSession(QWidget):
     def _on_data_cleared(self) -> None:
         self._state.measurement_set = None
         self._state.source_file = None
+        self._emit_tab_title()
         self._state.fit_results.clear()
         self._replica_panel.clear()
         self._summary_widget.clear()
@@ -688,7 +707,6 @@ class FittingSession(QWidget):
         self._bounds_panel.set_assay_type(assay_type)
         meta = ASSAY_REGISTRY[assay_type]
         self._update_axis_labels(meta.x_label, meta.y_label, meta.y_unit)
-        self.title_changed.emit(meta.display_name)
 
     def _on_conditions_changed(self) -> None:
         self._state.conditions = self._assay_panel.current_conditions()

--- a/gui/fitting_session.py
+++ b/gui/fitting_session.py
@@ -14,8 +14,6 @@ from PyQt6.QtWidgets import (
     QMessageBox,
     QScrollArea,
     QSplitter,
-    QStackedWidget,
-    QTabBar,
     QVBoxLayout,
     QWidget,
 )
@@ -34,6 +32,7 @@ from gui.widgets.assay_config_panel import AssayConfigPanel
 from gui.widgets.bounds_panel import BoundsPanel
 from gui.widgets.data_panel import DataPanel
 from gui.widgets.fit_config_panel import FitConfigPanel
+from gui.widgets.flat_tabs import FlatTabWidget
 from gui.widgets.info_button import InfoGroupBox
 from gui.widgets.preprocessing_panel import PreprocessingPanel
 from gui.widgets.replica_panel import ReplicaPanel
@@ -592,29 +591,16 @@ class FittingSession(QWidget):
         right_splitter = QSplitter(Qt.Orientation.Vertical)
         right_splitter.setChildrenCollapsible(False)
 
-        # Tabbed plot area: Fit Curve | Distributions
-        plot_area = QWidget()
-        plot_area_layout = QVBoxLayout(plot_area)
-        plot_area_layout.setContentsMargins(0, 0, 0, 0)
-        plot_area_layout.setSpacing(0)
-
-        self._plot_tab_bar = QTabBar()
-        self._plot_tab_bar.addTab('Fit Curve')
-        self._plot_tab_bar.addTab('Distributions')
-        plot_area_layout.addWidget(self._plot_tab_bar)
-
-        self._plot_stack = QStackedWidget()
+        # Tabbed plot area: Fit Curve | Distributions (flat/minimal, white pane).
         self._plot_widget = PlotWidget()
         self._distribution_widget = DistributionWidget()
-        self._plot_stack.addWidget(self._plot_widget)
-        self._plot_stack.addWidget(self._distribution_widget)
-        plot_area_layout.addWidget(self._plot_stack, stretch=1)
-
-        self._plot_tab_bar.currentChanged.connect(self._plot_stack.setCurrentIndex)
+        self._plot_tabs = FlatTabWidget(white_pane=True)
+        self._plot_tabs.addTab(self._plot_widget, 'Fit Curve')
+        self._plot_tabs.addTab(self._distribution_widget, 'Distributions')
 
         self._summary_widget = FitSummaryWidget()
 
-        right_splitter.addWidget(plot_area)
+        right_splitter.addWidget(self._plot_tabs)
         right_splitter.addWidget(self._summary_widget)
         right_splitter.setStretchFactor(0, 1)
         right_splitter.setStretchFactor(1, 1)

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -50,7 +50,8 @@ QToolBar {
     padding: 4px 10px;
     border-bottom: 1px solid rgba(0, 0, 0, 0.15);
 }
-QToolButton {
+/* Scoped to the toolbar so it does not leak into the tab bar's scroll arrows. */
+QToolBar QToolButton {
     padding: 5px 14px;
     min-width: 70px;
     border: 1px solid rgba(0, 0, 0, 0.22);
@@ -59,12 +60,12 @@ QToolButton {
         stop:0 rgba(255,255,255,0.95), stop:1 rgba(225,225,225,0.95));
     font-size: 12px;
 }
-QToolButton:hover {
+QToolBar QToolButton:hover {
     background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
         stop:0 rgba(255,255,255,1.0), stop:1 rgba(235,235,235,1.0));
     border-color: rgba(0, 0, 0, 0.32);
 }
-QToolButton:pressed {
+QToolBar QToolButton:pressed {
     background: rgba(195, 195, 195, 0.95);
 }
 QGroupBox {
@@ -139,10 +140,12 @@ class FittingMainWindow(QMainWindow):
         self._tabs = FlatTabWidget(
             closable=True,
             movable=True,
+            editable=True,
             add_callback=self._new_session,
             add_tooltip='New session (Ctrl+T)',
         )
         self._tabs.tabCloseRequested.connect(self._close_tab)
+        self._tabs.tab_renamed.connect(self._on_tab_renamed)
         self.setCentralWidget(self._tabs)
 
     def _setup_toolbar(self) -> None:
@@ -315,7 +318,7 @@ class FittingMainWindow(QMainWindow):
         session = FittingSession()
         session.title_changed.connect(lambda title, s=session: self._rename_tab(s, title))
         session.status_message.connect(self._statusbar.showMessage)
-        idx = self._tabs.addTab(session, 'New Session')
+        idx = self._tabs.addTab(session, 'Untitled')
         self._tabs.setCurrentIndex(idx)
 
     def _close_tab(self, idx: int) -> None:
@@ -332,6 +335,11 @@ class FittingMainWindow(QMainWindow):
         idx = self._tabs.indexOf(session)
         if idx >= 0:
             self._tabs.setTabText(idx, title)
+
+    def _on_tab_renamed(self, index: int, name: str) -> None:
+        session = self._tabs.widget(index)
+        if isinstance(session, FittingSession):
+            session.set_custom_tab_name(name)
 
     # ------------------------------------------------------------------
     # Toolbar / menu slots

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -10,9 +10,7 @@ from PyQt6.QtWidgets import (
     QMainWindow,
     QMenu,
     QMessageBox,
-    QPushButton,
     QStatusBar,
-    QTabWidget,
     QToolBar,
     QToolButton,
 )
@@ -22,6 +20,7 @@ from gui.fitting_session import FittingSession
 from gui.preferences import APP_NAME, ORG_NAME
 from gui.update_check import UpdateCheckWorker, is_newer
 from gui.update_dialog import UpdateAvailableDialog
+from gui.widgets.flat_tabs import FlatTabWidget
 
 
 class _SpinBoxWheelRedirect(QObject):
@@ -67,28 +66,6 @@ QToolButton:hover {
 }
 QToolButton:pressed {
     background: rgba(195, 195, 195, 0.95);
-}
-QTabBar {
-    alignment: left;
-}
-QTabBar::tab {
-    min-width: 100px;
-    padding: 6px 16px;
-    font-size: 12px;
-    border: 1px solid rgba(0, 0, 0, 0.25);
-    border-bottom: none;
-    border-top-left-radius: 5px;
-    border-top-right-radius: 5px;
-    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
-        stop:0 rgba(235,235,235,0.95), stop:1 rgba(215,215,215,0.95));
-    margin-right: 2px;
-}
-QTabBar::tab:selected {
-    background: white;
-    border-color: rgba(0, 0, 0, 0.3);
-}
-QTabBar::tab:!selected:hover {
-    background: rgba(245,245,245,0.95);
 }
 QGroupBox {
     font-size: 14px;
@@ -156,20 +133,16 @@ class FittingMainWindow(QMainWindow):
     # ------------------------------------------------------------------
 
     def _setup_tabs(self) -> None:
-        self._tabs = QTabWidget()
-        self._tabs.setTabsClosable(True)
+        # Flat/minimal session tabs with an inline "+" glued after the last tab.
+        # Closable + movable; FlatTabWidget hides the sole tab's close control so
+        # the bar can never be emptied.
+        self._tabs = FlatTabWidget(
+            closable=True,
+            movable=True,
+            add_callback=self._new_session,
+            add_tooltip='New session (Ctrl+T)',
+        )
         self._tabs.tabCloseRequested.connect(self._close_tab)
-        self._tabs.setMovable(True)
-        # Don't stretch tabs to fill the bar — left-aligned, natural width
-        self._tabs.tabBar().setExpanding(False)
-
-        # "+" button to open new sessions, placed at the top-right corner
-        plus_btn = QPushButton('+')
-        plus_btn.setFixedSize(28, 28)
-        plus_btn.setToolTip('New Session (Ctrl+T)')
-        plus_btn.clicked.connect(self._new_session)
-        self._tabs.setCornerWidget(plus_btn, Qt.Corner.TopRightCorner)
-
         self.setCentralWidget(self._tabs)
 
     def _setup_toolbar(self) -> None:

--- a/gui/widgets/assay_config_panel.py
+++ b/gui/widgets/assay_config_panel.py
@@ -187,13 +187,13 @@ class AssayConfigPanel(InfoGroupBox):
         ``assay_type_changed`` exactly once, like a user selection.
         """
         category = ASSAY_REGISTRY[assay_type].category
-        self._main_combo.blockSignals(True)
-        self._sub_combo.blockSignals(True)
+        main_blocked = self._main_combo.blockSignals(True)
+        sub_blocked = self._sub_combo.blockSignals(True)
         self._main_combo.setCurrentIndex(self._main_combo.findData(category))
         self._populate_sub(category)
         self._sub_combo.setCurrentIndex(self._sub_combo.findData(assay_type))
-        self._main_combo.blockSignals(False)
-        self._sub_combo.blockSignals(False)
+        self._main_combo.blockSignals(main_blocked)
+        self._sub_combo.blockSignals(sub_blocked)
         self._apply_assay(assay_type)
 
     # ------------------------------------------------------------------

--- a/gui/widgets/assay_config_panel.py
+++ b/gui/widgets/assay_config_panel.py
@@ -11,7 +11,7 @@ from core.assays.base import BaseAssay
 from core.assays.registry import ASSAY_REGISTRY, AssayType
 from core.units import Q_, Quantity
 from gui.assay_descriptions import ASSAY_DESCRIPTIONS
-from gui.widgets.assay_conditions import ASSAY_CONDITIONS, ConditionField, assay_class, condition_fields
+from gui.widgets.assay_conditions import ConditionField, assay_class, condition_fields
 from gui.widgets.info_button import InfoButton, InfoGroupBox
 from gui.widgets.numeric_inputs import NoScrollDoubleSpinBox
 
@@ -123,21 +123,22 @@ class _UnitWidget(QWidget):
 
 _SECTION_HELP_HTML = """
 <h3>Assay Configuration</h3>
-<p>Select the assay type (DBA, GDA, IDA, Dye Alone) and enter the
-experimental conditions (concentrations, known binding constants) used
-in the measurement. The form updates automatically when you switch
-assay type.</p>
-<p>See the <i>i</i> next to the assay selector for a description of
-each assay model.</p>
+<p>Pick the assay <b>category</b> (Competitive Displacement, Direct Binding,
+Calibration) in the first dropdown, then the specific <b>variant</b> in the
+second. The conditions form and parameter bounds update automatically when
+you switch.</p>
+<p>See the <i>i</i> next to the variant selector for a description of each
+assay model.</p>
 """
 
 
 class AssayConfigPanel(InfoGroupBox):
     """Registry-driven assay type selector and dynamic conditions form.
 
-    The combo box is populated from :data:`ASSAY_CONDITIONS`.  Switching the
-    assay type regenerates the conditions form automatically — no per-assay
-    widget code is needed.
+    A two-level selector — a *category* combo and a dependent *subtype* combo —
+    is derived from ``ASSAY_REGISTRY`` (grouped by ``AssayMetadata.category``).
+    Switching either combo regenerates the conditions form automatically — no
+    per-assay widget code is needed.
 
     Signals
     -------
@@ -154,6 +155,10 @@ class AssayConfigPanel(InfoGroupBox):
         super().__init__('Assay Configuration', 'Assay Configuration', _SECTION_HELP_HTML, parent)
         self._current_type: AssayType = AssayType.GDA
         self._field_widgets: dict[str, _UnitWidget] = {}
+        # category -> assay types (registry order); drives the two-level menu.
+        self._groups: dict[str, list[AssayType]] = {}
+        for at, meta in ASSAY_REGISTRY.items():
+            self._groups.setdefault(meta.category, []).append(at)
         self._setup_ui()
 
     # ------------------------------------------------------------------
@@ -176,8 +181,20 @@ class AssayConfigPanel(InfoGroupBox):
         return assay_class(self._current_type)
 
     def set_assay_type(self, assay_type: AssayType) -> None:
-        idx = list(ASSAY_CONDITIONS.keys()).index(assay_type)
-        self._combo.setCurrentIndex(idx)
+        """Programmatically select an assay (demo loader, tests).
+
+        Selects the matching category and subtype and emits
+        ``assay_type_changed`` exactly once, like a user selection.
+        """
+        category = ASSAY_REGISTRY[assay_type].category
+        self._main_combo.blockSignals(True)
+        self._sub_combo.blockSignals(True)
+        self._main_combo.setCurrentIndex(self._main_combo.findData(category))
+        self._populate_sub(category)
+        self._sub_combo.setCurrentIndex(self._sub_combo.findData(assay_type))
+        self._main_combo.blockSignals(False)
+        self._sub_combo.blockSignals(False)
+        self._apply_assay(assay_type)
 
     # ------------------------------------------------------------------
     # UI
@@ -186,21 +203,32 @@ class AssayConfigPanel(InfoGroupBox):
     def _setup_ui(self) -> None:
         layout = QVBoxLayout(self)
 
-        # Assay type selector + info button
-        self._combo = QComboBox()
-        for at in ASSAY_CONDITIONS:
-            self._combo.addItem(ASSAY_REGISTRY[at].display_name, userData=at)
-        self._combo.currentIndexChanged.connect(self._on_type_changed)
+        # Category selector (main) on its own row.
+        self._main_combo = QComboBox()
+        for category in self._groups:
+            self._main_combo.addItem(category, userData=category)
+        self._main_combo.currentIndexChanged.connect(self._on_main_changed)
+        layout.addWidget(self._main_combo)
 
+        # Subtype selector (dependent) + info button on the row below.
+        self._sub_combo = QComboBox()
         self._assay_info_btn = InfoButton('Assay type', '')
+        sub_row = QWidget()
+        sub_lay = QHBoxLayout(sub_row)
+        sub_lay.setContentsMargins(0, 0, 0, 0)
+        sub_lay.setSpacing(6)
+        sub_lay.addWidget(self._sub_combo, 1)
+        sub_lay.addWidget(self._assay_info_btn)
+        layout.addWidget(sub_row)
 
-        combo_row = QWidget()
-        combo_lay = QHBoxLayout(combo_row)
-        combo_lay.setContentsMargins(0, 0, 0, 0)
-        combo_lay.setSpacing(6)
-        combo_lay.addWidget(self._combo, 1)
-        combo_lay.addWidget(self._assay_info_btn)
-        layout.addWidget(combo_row)
+        # Initial selection: default assay, without emitting during construction.
+        default_category = ASSAY_REGISTRY[self._current_type].category
+        self._main_combo.blockSignals(True)
+        self._main_combo.setCurrentIndex(self._main_combo.findData(default_category))
+        self._main_combo.blockSignals(False)
+        self._populate_sub(default_category)
+        self._sub_combo.setCurrentIndex(self._sub_combo.findData(self._current_type))
+        self._sub_combo.currentIndexChanged.connect(self._on_sub_changed)
 
         # Dynamic conditions form
         self._form_widget = QWidget()
@@ -208,9 +236,22 @@ class AssayConfigPanel(InfoGroupBox):
         self._form_layout.setContentsMargins(0, 4, 0, 0)
         layout.addWidget(self._form_widget)
 
-        # Populate initial form + info text
+        # Populate initial form + info text (no signal emission — matches prior init).
         self._rebuild_form(self._current_type)
         self._refresh_assay_info(self._current_type)
+
+    def _populate_sub(self, category: str) -> None:
+        """Fill the subtype combo with the assays in ``category`` (index 0 selected).
+
+        Restores the combo's prior signal-blocked state so callers that have
+        pre-blocked it stay blocked.
+        """
+        was_blocked = self._sub_combo.blockSignals(True)
+        self._sub_combo.clear()
+        for at in self._groups[category]:
+            self._sub_combo.addItem(ASSAY_REGISTRY[at].subtype_label, userData=at)
+        self._sub_combo.setCurrentIndex(0)
+        self._sub_combo.blockSignals(was_blocked)
 
     def _refresh_assay_info(self, assay_type: AssayType) -> None:
         title, body = ASSAY_DESCRIPTIONS.get(
@@ -248,10 +289,23 @@ class AssayConfigPanel(InfoGroupBox):
     # Slots
     # ------------------------------------------------------------------
 
-    def _on_type_changed(self, idx: int) -> None:
-        at = self._combo.itemData(idx)
-        self._current_type = at
-        self._rebuild_form(at)
-        self._refresh_assay_info(at)
-        self.assay_type_changed.emit(at)
+    def _apply_assay(self, assay_type: AssayType) -> None:
+        """Adopt a newly selected assay: rebuild the form/info and announce it."""
+        self._current_type = assay_type
+        self._rebuild_form(assay_type)
+        self._refresh_assay_info(assay_type)
+        self.assay_type_changed.emit(assay_type)
         self.conditions_changed.emit()
+
+    def _on_main_changed(self, idx: int) -> None:
+        # Repopulate the subtype combo (signals blocked), then apply its first
+        # entry — exactly one assay_type_changed emission per category switch.
+        category = self._main_combo.itemData(idx)
+        self._populate_sub(category)
+        self._apply_assay(self._sub_combo.itemData(0))
+
+    def _on_sub_changed(self, idx: int) -> None:
+        at = self._sub_combo.itemData(idx)
+        if at is None:  # transient empty state during repopulation
+            return
+        self._apply_assay(at)

--- a/gui/widgets/flat_tabs.py
+++ b/gui/widgets/flat_tabs.py
@@ -15,14 +15,14 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
-from PyQt6.QtCore import Qt
-from PyQt6.QtGui import QResizeEvent
-from PyQt6.QtWidgets import QStyle, QTabBar, QTabWidget, QToolButton
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtGui import QResizeEvent, QWheelEvent
+from PyQt6.QtWidgets import QAbstractButton, QLineEdit, QStyle, QTabBar, QTabWidget, QToolButton
 
 # Authoritative flat/minimal QSS. The 2px transparent bottom border lives on the
 # base ::tab rule (not only on :selected) so selecting a tab never shifts its
-# label. The QTabBar QToolButton rule neutralises the app-wide boxed QToolButton
-# style for the overflow scroll chevrons (and the inline "+").
+# label. ::scroller collapses the native overflow arrows to nothing (we scroll
+# the tab strip by mouse wheel instead — see FlatTabBar.wheelEvent).
 _FLAT_TABS_QSS = """
 QTabWidget#flatTabs::pane {
     border: none;
@@ -54,13 +54,16 @@ QTabWidget#flatTabs QTabBar QToolButton {
     border: none;
     min-width: 0;
 }
+/* No native overflow chevrons — collapse the scroller region; wheel scrolls. */
+QTabWidget#flatTabs QTabBar::scroller {
+    width: 0px;
+}
 """
 
 _WHITE_PANE_QSS = 'QTabWidget#flatTabs::pane { background: #FFFFFF; }'
 
 # Inline "+": borderless, transparent, neutral grey that darkens on hover, glyph
-# a touch larger than the labels. Its own sheet overrides the app-wide QToolButton
-# box (border / gradient / min-width) so it never renders as a boxed button.
+# a touch larger than the labels. Its own sheet overrides any inherited button box.
 _ADD_BUTTON_QSS = """
 QToolButton {
     border: none;
@@ -140,6 +143,31 @@ class FlatTabBar(QTabBar):
         super().resizeEvent(event)
         self._reposition_add_button()
 
+    def _scroll_buttons(self) -> list[QAbstractButton]:
+        # QTabBar's two internal overflow scroll buttons: every QAbstractButton
+        # child that isn't our own "+" or a tab close button. The QSS collapses
+        # them to zero width (no chevrons); we drive them from the wheel.
+        return [
+            c
+            for c in self.children()
+            if isinstance(c, QAbstractButton) and c is not self._add_button and not isinstance(c, _FlatCloseButton)
+        ]
+
+    def wheelEvent(self, event: QWheelEvent) -> None:
+        # Scroll the tab strip with the wheel when it overflows. The native scroll
+        # arrows are collapsed to zero width (QSS) but still functional; pick the
+        # one by its arrow direction (robust to their collapsed geometry) —
+        # RightArrow scrolls toward later tabs, LeftArrow back.
+        delta = event.angleDelta().y() or event.angleDelta().x()
+        if delta:
+            want = Qt.ArrowType.RightArrow if delta < 0 else Qt.ArrowType.LeftArrow
+            for b in self._scroll_buttons():
+                if isinstance(b, QToolButton) and b.arrowType() == want:
+                    b.click()
+                    event.accept()
+                    return
+        super().wheelEvent(event)
+
 
 class _FlatCloseButton(QToolButton):
     """Borderless neutral "✕" close affordance for a flat tab."""
@@ -152,6 +180,35 @@ class _FlatCloseButton(QToolButton):
         self.setFocusPolicy(Qt.FocusPolicy.NoFocus)
         self.setCursor(Qt.CursorShape.ArrowCursor)
         self.setStyleSheet(_CLOSE_BUTTON_QSS)
+
+
+class _TabRenameEdit(QLineEdit):
+    """One-shot inline editor for a tab label.
+
+    Emits ``done(text, committed)`` exactly once: committed on Enter or focus-out,
+    cancelled (``committed=False``) on Escape. The ``_finished`` guard avoids the
+    Escape-then-focus-out double-fire.
+    """
+
+    done = pyqtSignal(str, bool)
+
+    def __init__(self, text: str, parent=None) -> None:
+        super().__init__(text, parent)
+        self._finished = False
+        self.setFrame(False)
+        self.editingFinished.connect(lambda: self._finish(True))
+
+    def keyPressEvent(self, event) -> None:
+        if event.key() == Qt.Key.Key_Escape:
+            self._finish(False)
+        else:
+            super().keyPressEvent(event)
+
+    def _finish(self, commit: bool) -> None:
+        if self._finished:
+            return
+        self._finished = True
+        self.done.emit(self.text(), commit)
 
 
 class FlatTabWidget(QTabWidget):
@@ -168,7 +225,17 @@ class FlatTabWidget(QTabWidget):
         If given, show an inline "+" after the last tab that calls this on click.
     add_tooltip : str
         Tooltip for the "+".
+    editable : bool
+        If True, double-clicking a tab opens an inline editor; committing emits
+        ``tab_renamed(index, text)`` for the caller to apply.
+
+    Signals
+    -------
+    tab_renamed(int, str)
+        Emitted when a tab is renamed inline — (index, new text).
     """
+
+    tab_renamed = pyqtSignal(int, str)
 
     def __init__(
         self,
@@ -176,6 +243,7 @@ class FlatTabWidget(QTabWidget):
         closable: bool = False,
         movable: bool = False,
         white_pane: bool = False,
+        editable: bool = False,
         add_callback: Callable[[], None] | None = None,
         add_tooltip: str = 'New tab',
         parent=None,
@@ -187,9 +255,14 @@ class FlatTabWidget(QTabWidget):
         self.setDocumentMode(True)
         self.tabBar().setExpanding(False)
         self.tabBar().setDrawBase(False)
+        # Keep full labels and scroll on overflow (native chevrons) — don't elide.
+        self.tabBar().setElideMode(Qt.TextElideMode.ElideNone)
         self.setUsesScrollButtons(True)
         self._closable = closable
         self.setMovable(movable)
+        self._editor: _TabRenameEdit | None = None
+        if editable:
+            self.tabBarDoubleClicked.connect(self._begin_rename)
         if add_callback is not None:
             self.tabBar().set_add_callback(add_callback, add_tooltip)
 
@@ -235,3 +308,30 @@ class FlatTabWidget(QTabWidget):
             btn = bar.tabButton(i, side)
             if btn is not None:
                 btn.setVisible(not single)
+
+    # ------------------------------------------------------------------
+    # Inline rename (when editable)
+    # ------------------------------------------------------------------
+
+    def _begin_rename(self, index: int) -> None:
+        if index < 0 or self._editor is not None:
+            return
+        rect = self.tabBar().tabRect(index)
+        if rect.isNull():
+            return
+        editor = _TabRenameEdit(self.tabText(index), self.tabBar())
+        editor.setGeometry(rect)
+        editor.selectAll()
+        editor.done.connect(lambda text, ok, i=index: self._finish_rename(i, text, ok))
+        self._editor = editor
+        editor.show()
+        editor.setFocus()
+
+    def _finish_rename(self, index: int, text: str, commit: bool) -> None:
+        editor, self._editor = self._editor, None
+        if editor is not None:
+            editor.deleteLater()
+        # The consumer applies the name (the session resolves empty -> filename),
+        # so it stays the single source of truth for the title.
+        if commit and 0 <= index < self.count():
+            self.tab_renamed.emit(index, text)

--- a/gui/widgets/flat_tabs.py
+++ b/gui/widgets/flat_tabs.py
@@ -1,0 +1,237 @@
+"""Flat / minimal tab widgets — one reusable style for every tab in the app.
+
+Implements the flat/minimal tab design (see ``flat_minimal_tabs_spec.md``):
+transparent tabs, normal-weight labels, a 2px underline on the *active* tab only
+(the 2px is reserved in every state so the label never shifts vertically), a
+single ``#ECECEC`` hairline under the row, left-aligned tabs, and an inline "+"
+button glued immediately after the last tab (not a corner widget).
+
+Used by both tab systems:
+- session tabs — closable, movable, with a "+" that opens a new session;
+- plot tabs — fixed Fit Curve / Distributions over a white content pane.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QResizeEvent
+from PyQt6.QtWidgets import QStyle, QTabBar, QTabWidget, QToolButton
+
+# Authoritative flat/minimal QSS. The 2px transparent bottom border lives on the
+# base ::tab rule (not only on :selected) so selecting a tab never shifts its
+# label. The QTabBar QToolButton rule neutralises the app-wide boxed QToolButton
+# style for the overflow scroll chevrons (and the inline "+").
+_FLAT_TABS_QSS = """
+QTabWidget#flatTabs::pane {
+    border: none;
+    border-top: 1px solid #ECECEC;
+}
+QTabWidget#flatTabs > QTabBar {
+    qproperty-drawBase: 0;
+}
+QTabWidget#flatTabs QTabBar::tab {
+    background: transparent;
+    color: #888888;
+    border: none;
+    border-bottom: 2px solid transparent;
+    padding: 10px 16px;
+    margin-right: 4px;
+}
+QTabWidget#flatTabs QTabBar::tab:hover {
+    color: #222222;
+}
+QTabWidget#flatTabs QTabBar::tab:selected {
+    color: #111111;
+    border-bottom: 2px solid #111111;
+}
+QTabWidget#flatTabs QTabBar::tab:disabled {
+    color: #C8C8C8;
+}
+QTabWidget#flatTabs QTabBar QToolButton {
+    background: transparent;
+    border: none;
+    min-width: 0;
+}
+"""
+
+_WHITE_PANE_QSS = 'QTabWidget#flatTabs::pane { background: #FFFFFF; }'
+
+# Inline "+": borderless, transparent, neutral grey that darkens on hover, glyph
+# a touch larger than the labels. Its own sheet overrides the app-wide QToolButton
+# box (border / gradient / min-width) so it never renders as a boxed button.
+_ADD_BUTTON_QSS = """
+QToolButton {
+    border: none;
+    background: transparent;
+    color: #888888;
+    font-size: 18px;
+    min-width: 0;
+    padding: 0 10px;
+}
+QToolButton:hover {
+    color: #111111;
+}
+"""
+
+# Minimal close affordance: a faint neutral "✕" that darkens on hover — no box,
+# no colour. Replaces the platform default close glyph (which can render heavy or
+# coloured, e.g. a red box) so the look is identical on every style / OS.
+_CLOSE_BUTTON_QSS = """
+QToolButton {
+    border: none;
+    background: transparent;
+    color: #BBBBBB;
+    font-size: 13px;
+    min-width: 0;
+    padding: 0 2px;
+}
+QToolButton:hover {
+    color: #111111;
+}
+"""
+
+
+class FlatTabBar(QTabBar):
+    """Tab bar that keeps an optional inline "+" button after the last tab."""
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self._add_button: QToolButton | None = None
+
+    def set_add_callback(self, callback: Callable[[], None], tooltip: str = 'New tab') -> None:
+        """Create the inline "+" affordance and run ``callback`` on click."""
+        if self._add_button is None:
+            btn = QToolButton(self)
+            btn.setText('+')
+            btn.setToolTip(tooltip)
+            btn.setAutoRaise(True)
+            btn.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+            btn.setCursor(Qt.CursorShape.ArrowCursor)
+            btn.setStyleSheet(_ADD_BUTTON_QSS)
+            self._add_button = btn
+        self._add_button.clicked.connect(callback)
+        self._reposition_add_button()
+
+    def _reposition_add_button(self) -> None:
+        btn = self._add_button
+        if btn is None:
+            return
+        if self.count() == 0:
+            btn.hide()
+            return
+        last = self.tabRect(self.count() - 1)
+        if last.isNull():
+            btn.hide()
+            return
+        btn.adjustSize()
+        # 4px gap after the last tab (matches the inter-tab gap), vertically centred.
+        btn.move(last.right() + 4, last.center().y() - btn.height() // 2)
+        btn.show()
+
+    # tabLayoutChange fires on every layout change — add, remove, move, resize,
+    # overflow scroll — so it is the single hook needed to keep "+" glued last.
+    def tabLayoutChange(self) -> None:
+        super().tabLayoutChange()
+        self._reposition_add_button()
+
+    def resizeEvent(self, event: QResizeEvent) -> None:
+        super().resizeEvent(event)
+        self._reposition_add_button()
+
+
+class _FlatCloseButton(QToolButton):
+    """Borderless neutral "✕" close affordance for a flat tab."""
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self.setText('✕')
+        self.setToolTip('Close')
+        self.setAutoRaise(True)
+        self.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+        self.setCursor(Qt.CursorShape.ArrowCursor)
+        self.setStyleSheet(_CLOSE_BUTTON_QSS)
+
+
+class FlatTabWidget(QTabWidget):
+    """A ``QTabWidget`` rendered in the flat/minimal style (see module docstring).
+
+    Parameters
+    ----------
+    closable, movable : bool
+        Enable the close affordance / drag-reordering.
+    white_pane : bool
+        Fill the content pane white (``#FFFFFF``). Off by default so the pane
+        inherits the window background.
+    add_callback : Callable[[], None] | None
+        If given, show an inline "+" after the last tab that calls this on click.
+    add_tooltip : str
+        Tooltip for the "+".
+    """
+
+    def __init__(
+        self,
+        *,
+        closable: bool = False,
+        movable: bool = False,
+        white_pane: bool = False,
+        add_callback: Callable[[], None] | None = None,
+        add_tooltip: str = 'New tab',
+        parent=None,
+    ) -> None:
+        super().__init__(parent)
+        self.setObjectName('flatTabs')
+        self.setTabBar(FlatTabBar(self))
+        self.setStyleSheet(_FLAT_TABS_QSS + (_WHITE_PANE_QSS if white_pane else ''))
+        self.setDocumentMode(True)
+        self.tabBar().setExpanding(False)
+        self.tabBar().setDrawBase(False)
+        self.setUsesScrollButtons(True)
+        self._closable = closable
+        self.setMovable(movable)
+        if add_callback is not None:
+            self.tabBar().set_add_callback(add_callback, add_tooltip)
+
+    def tabInserted(self, index: int) -> None:
+        super().tabInserted(index)
+        if self._closable:
+            self._install_close_button(index)
+        self._update_close_buttons()
+
+    def tabRemoved(self, index: int) -> None:
+        super().tabRemoved(index)
+        self._update_close_buttons()
+
+    def _close_side(self) -> QTabBar.ButtonPosition:
+        # Platform convention: close button is left-side on macOS, right elsewhere.
+        return QTabBar.ButtonPosition(self.style().styleHint(QStyle.StyleHint.SH_TabBar_CloseButtonPosition))
+
+    def _install_close_button(self, index: int) -> None:
+        bar = self.tabBar()
+        btn = _FlatCloseButton(bar)
+        btn.clicked.connect(lambda: self._emit_close_for(btn))
+        bar.setTabButton(index, self._close_side(), btn)
+
+    def _emit_close_for(self, btn: QToolButton) -> None:
+        # Map the clicked button to its current tab index (robust to reordering),
+        # then route through the standard close signal the app already handles.
+        bar = self.tabBar()
+        side = self._close_side()
+        for i in range(self.count()):
+            if bar.tabButton(i, side) is btn:
+                self.tabCloseRequested.emit(i)
+                return
+
+    def _update_close_buttons(self) -> None:
+        # Spec §8.1: never allow zero tabs — hide the close control on the sole
+        # remaining tab so it cannot be closed to empty; re-show it once ≥2 tabs.
+        if not self._closable:
+            return
+        bar = self.tabBar()
+        side = self._close_side()
+        single = self.count() == 1
+        for i in range(self.count()):
+            btn = bar.tabButton(i, side)
+            if btn is not None:
+                btn.setVisible(not single)

--- a/gui/widgets/flat_tabs.py
+++ b/gui/widgets/flat_tabs.py
@@ -104,16 +104,20 @@ class FlatTabBar(QTabBar):
         self._add_button: QToolButton | None = None
 
     def set_add_callback(self, callback: Callable[[], None], tooltip: str = 'New tab') -> None:
-        """Create the inline "+" affordance and run ``callback`` on click."""
+        """Create (or reconfigure) the inline "+" affordance; run ``callback`` on click."""
         if self._add_button is None:
             btn = QToolButton(self)
             btn.setText('+')
-            btn.setToolTip(tooltip)
             btn.setAutoRaise(True)
             btn.setFocusPolicy(Qt.FocusPolicy.NoFocus)
             btn.setCursor(Qt.CursorShape.ArrowCursor)
             btn.setStyleSheet(_ADD_BUTTON_QSS)
             self._add_button = btn
+        self._add_button.setToolTip(tooltip)
+        try:
+            self._add_button.clicked.disconnect()
+        except TypeError:
+            pass  # nothing connected yet
         self._add_button.clicked.connect(callback)
         self._reposition_add_button()
 
@@ -162,7 +166,9 @@ class FlatTabBar(QTabBar):
         if delta:
             want = Qt.ArrowType.RightArrow if delta < 0 else Qt.ArrowType.LeftArrow
             for b in self._scroll_buttons():
-                if isinstance(b, QToolButton) and b.arrowType() == want:
+                # Only intercept when a matching arrow can actually scroll —
+                # otherwise let the wheel propagate (don't swallow it).
+                if isinstance(b, QToolButton) and b.arrowType() == want and b.isEnabled():
                     b.click()
                     event.accept()
                     return

--- a/tests/unit/gui/test_assay_config_panel.py
+++ b/tests/unit/gui/test_assay_config_panel.py
@@ -1,0 +1,66 @@
+"""Two-level (category → subtype) assay selector behaviour.
+
+Verifies the dependent dropdowns react correctly and that exactly one
+``assay_type_changed`` is emitted per selection — the contract the fitting
+session and demo loader rely on.
+"""
+
+import pytest
+
+from core.assays import AssayType
+from core.assays.registry import ASSAY_REGISTRY
+from gui.widgets.assay_config_panel import AssayConfigPanel
+
+
+@pytest.fixture
+def panel(qapp):
+    return AssayConfigPanel()
+
+
+def _direct_binding_types():
+    return [at for at, m in ASSAY_REGISTRY.items() if m.category == 'Direct Binding']
+
+
+def test_default_is_gda_without_emission(qapp):
+    emitted = []
+    p = AssayConfigPanel()
+    p.assay_type_changed.connect(emitted.append)
+    # Construction must not fire the signal (matches prior single-combo init).
+    assert p.current_assay_type() is AssayType.GDA
+    assert emitted == []
+
+
+def test_set_assay_type_selects_category_and_subtype_once(panel):
+    emitted = []
+    panel.assay_type_changed.connect(emitted.append)
+
+    panel.set_assay_type(AssayType.IDA)
+
+    assert panel.current_assay_type() is AssayType.IDA
+    assert panel._main_combo.currentData() == 'Competitive Displacement'
+    assert panel._sub_combo.currentData() is AssayType.IDA
+    assert emitted == [AssayType.IDA]  # exactly one emission
+
+
+def test_changing_category_repopulates_subtypes_and_emits_once(panel):
+    emitted = []
+    panel.assay_type_changed.connect(emitted.append)
+
+    panel._main_combo.setCurrentIndex(panel._main_combo.findData('Direct Binding'))
+
+    direct = _direct_binding_types()
+    sub_data = [panel._sub_combo.itemData(i) for i in range(panel._sub_combo.count())]
+    assert sub_data == direct  # subtype combo now lists exactly the category's assays
+    assert panel.current_assay_type() is direct[0]  # first subtype applied
+    assert emitted == [direct[0]]  # one emission for the category switch, not two
+
+
+def test_changing_subtype_within_category_emits_that_assay(panel):
+    panel.set_assay_type(AssayType.DBA_HtoD)  # Direct Binding
+    emitted = []
+    panel.assay_type_changed.connect(emitted.append)
+
+    panel._sub_combo.setCurrentIndex(panel._sub_combo.findData(AssayType.DBA_H2G))
+
+    assert panel.current_assay_type() is AssayType.DBA_H2G
+    assert emitted == [AssayType.DBA_H2G]

--- a/tests/unit/gui/test_fitting_session_layout.py
+++ b/tests/unit/gui/test_fitting_session_layout.py
@@ -59,5 +59,22 @@ def test_sidebar_has_no_hard_maxwidth_cap(qapp):
     scroll = session._sidebar_scroll
     # No finite upper bound: maximumWidth stays at Qt's sentinel max.
     assert scroll.maximumWidth() == QWIDGETSIZE_MAX
-    # A sane floor remains so the panel can't collapse to an unusable sliver.
-    assert 0 < scroll.minimumWidth() <= 320
+
+
+def test_sidebar_reserves_content_width_so_it_never_clips(qapp):
+    """The sidebar must advertise at least its content's width to the splitter.
+
+    A plain ``QScrollArea`` reports a near-zero width hint (≈90px) regardless of
+    its content (~336px here), so a ``QSplitter`` shrinks it until the content
+    clips at the plot boundary. ``_SidebarScrollArea`` propagates the content's
+    width (plus the vertical scrollbar) as its own minimum, so the splitter
+    honors it and the plot pane yields instead — the content is structurally
+    unclippable, whatever the panels need.
+    """
+    from gui.fitting_session import FittingSession
+
+    session = FittingSession()
+    scroll = session._sidebar_scroll
+    content = scroll.widget()
+    scrollbar = scroll.verticalScrollBar().sizeHint().width()
+    assert scroll.minimumSizeHint().width() >= content.minimumSizeHint().width() + scrollbar

--- a/tests/unit/gui/test_fitting_session_layout.py
+++ b/tests/unit/gui/test_fitting_session_layout.py
@@ -1,10 +1,11 @@
 """Regression guard: the plot widget must stay embedded after any import.
 
 A previous EnSight code path ran a modal ``QInputDialog`` mid-load, which
-detached the plot from its ``QStackedWidget`` (it overlapped the sidebar and
+detached the plot from its tab container (it overlapped the sidebar and
 floated above the Fit Curve tab). The fix removed the mid-load modal. This
-test asserts the plot widget remains embedded — index 0 of the stack, never a
-top-level window — across an EnSight import and a subsequent channel switch.
+test asserts the plot widget remains embedded — the first page of the plot
+tab widget, never a top-level window — across an EnSight import and a
+subsequent channel switch.
 """
 
 from __future__ import annotations
@@ -20,10 +21,11 @@ ENSIGHT_FIXTURE = Path(__file__).parent.parent.parent / 'data' / 'ensight' / 'tr
 
 def _assert_embedded(session):
     pw = session._plot_widget
-    stack = session._plot_stack
-    assert stack.indexOf(pw) == 0
+    tabs = session._plot_tabs
+    # The plot is the first page of the flat plot-tab widget, never detached
+    # into a top-level window.
+    assert tabs.indexOf(pw) == 0
     assert not pw.isWindow()
-    assert pw.parent() is stack
 
 
 def test_plot_stays_embedded_through_ensight_load_and_switch(qapp):

--- a/tests/unit/gui/test_flat_tabs.py
+++ b/tests/unit/gui/test_flat_tabs.py
@@ -1,0 +1,84 @@
+"""Flat/minimal tab widget behaviour (``gui/widgets/flat_tabs.py``).
+
+Behavioural contracts for the shared ``FlatTabWidget``: the inline "+" lives
+after the last tab (not in a corner) and invokes its callback, and the bar can
+never be emptied. Visual fidelity (colours, underline) is checked by eye against
+the spec, not asserted here.
+"""
+
+import pytest
+
+pytest.importorskip('PyQt6')
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import QTabBar, QWidget
+
+from gui.widgets.flat_tabs import FlatTabBar, FlatTabWidget
+
+
+def test_flat_config(qapp):
+    tabs = FlatTabWidget()
+    assert tabs.objectName() == 'flatTabs'
+    assert tabs.documentMode()
+    assert isinstance(tabs.tabBar(), FlatTabBar)
+    assert not tabs.tabBar().expanding()  # left-aligned, not stretched
+    assert not tabs.tabBar().drawBase()  # no platform base line
+
+
+def test_inline_add_button_after_last_tab_and_calls_back(qapp):
+    calls = []
+    tabs = FlatTabWidget(add_callback=lambda: calls.append(1))
+    tabs.addTab(QWidget(), 'A')
+    tabs.addTab(QWidget(), 'B')
+    tabs.resize(400, 80)
+    tabs.show()
+    qapp.processEvents()
+    try:
+        # Inline, not a corner widget (spec §5.1): the "+" is a child of the bar.
+        assert tabs.cornerWidget(Qt.Corner.TopRightCorner) is None
+        btn = tabs.tabBar()._add_button
+        assert btn is not None and btn.parent() is tabs.tabBar()
+        # Glued to the right of the last tab.
+        assert btn.x() >= tabs.tabBar().tabRect(tabs.count() - 1).right()
+        # Clicking runs the callback (the app wires this to "new session").
+        btn.click()
+        assert calls == [1]
+    finally:
+        tabs.close()
+
+
+def _close_button(bar, i):
+    for side in (QTabBar.ButtonPosition.LeftSide, QTabBar.ButtonPosition.RightSide):
+        b = bar.tabButton(i, side)
+        if b is not None:
+            return b
+    return None
+
+
+def test_never_zero_tabs_hides_the_sole_close_button(qapp):
+    tabs = FlatTabWidget(closable=True)
+    tabs.addTab(QWidget(), 'only')
+    tabs.show()
+    qapp.processEvents()
+    try:
+        bar = tabs.tabBar()
+        # Sole tab: its close control is hidden so it cannot be closed to empty.
+        assert not _close_button(bar, 0).isVisible()
+        # With a second tab, both close controls are shown again.
+        tabs.addTab(QWidget(), 'second')
+        qapp.processEvents()
+        assert _close_button(bar, 0).isVisible()
+        assert _close_button(bar, 1).isVisible()
+    finally:
+        tabs.close()
+
+
+def test_plot_style_widget_has_no_add_button_and_is_fixed(qapp):
+    # The plot tabs (Fit Curve / Distributions) are fixed: no "+", not closable,
+    # not movable.
+    tabs = FlatTabWidget(white_pane=True)
+    tabs.addTab(QWidget(), 'Fit Curve')
+    tabs.addTab(QWidget(), 'Distributions')
+    assert tabs.tabBar()._add_button is None
+    assert not tabs.tabsClosable()
+    assert not tabs.isMovable()

--- a/tests/unit/gui/test_flat_tabs.py
+++ b/tests/unit/gui/test_flat_tabs.py
@@ -10,7 +10,8 @@ import pytest
 
 pytest.importorskip('PyQt6')
 
-from PyQt6.QtCore import Qt
+from PyQt6.QtCore import QPoint, QPointF, Qt
+from PyQt6.QtGui import QWheelEvent
 from PyQt6.QtWidgets import QTabBar, QWidget
 
 from gui.widgets.flat_tabs import FlatTabBar, FlatTabWidget
@@ -23,6 +24,9 @@ def test_flat_config(qapp):
     assert isinstance(tabs.tabBar(), FlatTabBar)
     assert not tabs.tabBar().expanding()  # left-aligned, not stretched
     assert not tabs.tabBar().drawBase()  # no platform base line
+    # Overflow: keep full labels and wheel-scroll (don't elide); chevrons hidden.
+    assert tabs.usesScrollButtons()
+    assert tabs.tabBar().elideMode() == Qt.TextElideMode.ElideNone
 
 
 def test_inline_add_button_after_last_tab_and_calls_back(qapp):
@@ -82,3 +86,73 @@ def test_plot_style_widget_has_no_add_button_and_is_fixed(qapp):
     assert tabs.tabBar()._add_button is None
     assert not tabs.tabsClosable()
     assert not tabs.isMovable()
+
+
+def test_editable_double_click_commits_rename(qapp):
+    renamed = []
+    tabs = FlatTabWidget(editable=True)
+    tabs.tab_renamed.connect(lambda i, name: renamed.append((i, name)))
+    tabs.addTab(QWidget(), 'Untitled')
+    tabs.show()
+    qapp.processEvents()
+    try:
+        tabs.tabBarDoubleClicked.emit(0)  # double-click tab 0 → inline editor
+        editor = tabs._editor
+        assert editor is not None
+        editor.setText('Control run')
+        editor._finish(True)  # commit (Enter / focus-out)
+        assert renamed == [(0, 'Control run')]
+        assert tabs._editor is None  # editor torn down
+    finally:
+        tabs.close()
+
+
+def test_editable_rename_escape_cancels(qapp):
+    renamed = []
+    tabs = FlatTabWidget(editable=True)
+    tabs.tab_renamed.connect(lambda i, name: renamed.append((i, name)))
+    tabs.addTab(QWidget(), 'Untitled')
+    tabs.show()
+    qapp.processEvents()
+    try:
+        tabs.tabBarDoubleClicked.emit(0)
+        tabs._editor.setText('X')
+        tabs._editor._finish(False)  # Escape → cancel, no rename
+        assert renamed == []
+        assert tabs._editor is None
+    finally:
+        tabs.close()
+
+
+def test_wheel_scrolls_overflowing_tabs(qapp):
+    tabs = FlatTabWidget()
+    for i in range(20):
+        tabs.addTab(QWidget(), f'tryptamine_{i}')
+    tabs.resize(360, 60)
+    tabs.show()
+    qapp.processEvents()
+    bar = tabs.tabBar()
+
+    def wheel(d):
+        ev = QWheelEvent(
+            QPointF(150, 20),
+            QPointF(150, 20),
+            QPoint(0, d),
+            QPoint(0, d),
+            Qt.MouseButton.NoButton,
+            Qt.KeyboardModifier.NoModifier,
+            Qt.ScrollPhase.NoScrollPhase,
+            False,
+        )
+        qapp.sendEvent(bar, ev)
+        qapp.processEvents()
+
+    try:
+        start = bar.tabRect(0).x()
+        wheel(-120)  # wheel away → scroll toward later tabs (strip slides left)
+        scrolled = bar.tabRect(0).x()
+        assert scrolled < start
+        wheel(120)  # wheel back
+        assert bar.tabRect(0).x() > scrolled
+    finally:
+        tabs.close()

--- a/tests/unit/gui/test_session_tab_title.py
+++ b/tests/unit/gui/test_session_tab_title.py
@@ -1,0 +1,42 @@
+"""Session tab-title logic: dataset filename, custom name, and fallbacks.
+
+The session owns its title (emitted via ``title_changed``): a user-set custom
+name wins, else the loaded dataset's filename stem, else "Untitled". A custom
+name persists across data loads until cleared (renamed to empty).
+"""
+
+import pytest
+
+pytest.importorskip('PyQt6')
+
+
+def test_tab_title_resolution_and_emission(qapp):
+    from gui.fitting_session import FittingSession
+
+    s = FittingSession()
+    emitted = []
+    s.title_changed.connect(emitted.append)
+
+    # No file loaded yet → "Untitled".
+    assert s._tab_title() == 'Untitled'
+
+    # A loaded dataset → filename stem (no extension), emitted.
+    s._state.source_file = '/data/tryptamine_424.txt'
+    s._emit_tab_title()
+    assert s._tab_title() == 'tryptamine_424'
+    assert emitted[-1] == 'tryptamine_424'
+
+    # A custom name wins and persists across a later data load.
+    s.set_custom_tab_name('Control run')
+    assert emitted[-1] == 'Control run'
+    s._state.source_file = '/data/other.csv'
+    assert s._tab_title() == 'Control run'
+
+    # Renaming to empty reverts to the current filename.
+    s.set_custom_tab_name('   ')
+    assert s._tab_title() == 'other'
+    assert emitted[-1] == 'other'
+
+    # Clearing the data → "Untitled".
+    s._state.source_file = None
+    assert s._tab_title() == 'Untitled'

--- a/tests/unit/test_assay_categories.py
+++ b/tests/unit/test_assay_categories.py
@@ -1,0 +1,27 @@
+"""Category / subtype metadata that drives the two-level assay menu.
+
+Guards the GUI contract: every registered assay is menu-reachable with a
+non-empty category and a subtype label that is unambiguous within its category.
+A new assay added without these would silently break the selector.
+"""
+
+from collections import Counter
+
+from core.assays.registry import ASSAY_REGISTRY
+
+
+def test_every_assay_has_category_and_subtype_label():
+    for assay_type, meta in ASSAY_REGISTRY.items():
+        assert meta.category, f'{assay_type.name} has no category'
+        assert meta.subtype_label, f'{assay_type.name} has no subtype_label'
+
+
+def test_subtype_labels_unique_within_category():
+    # Two assays in one category must not share a subtype label, or the sub
+    # dropdown would show indistinguishable entries.
+    by_category: dict[str, list[str]] = {}
+    for meta in ASSAY_REGISTRY.values():
+        by_category.setdefault(meta.category, []).append(meta.subtype_label)
+    for category, labels in by_category.items():
+        dupes = [lbl for lbl, n in Counter(labels).items() if n > 1]
+        assert not dupes, f'duplicate subtype labels in {category!r}: {dupes}'


### PR DESCRIPTION
Rolling branch for a round of GUI polish — items land here incrementally before merge. Presentation-only (no model/parameter changes); fast test layer green with new GUI tests per item.

## Done

- **Two-level assay selector** — the flat dropdown becomes a dependent **category → subtype** menu, grouped by binding mechanism (Competitive Displacement / Direct Binding / Calibration). Grouping is data on `AssayMetadata`; `AssayConfigPanel`'s public API is unchanged.
- **Sidebar no longer clips** — `_SidebarScrollArea` advertises its content width to the splitter, so the plot pane yields instead of the sidebar clipping. No magic widths.
- **Flat / minimal tabs** — one reusable `FlatTabWidget` for both the session tabs and the plot tabs (Fit Curve / Distributions): transparent tabs, a `#111` underline on the active tab only, an `#ECECEC` hairline, inline `+`, neutral `✕` close; the last tab can't be closed to empty.
- **Dataset-named, editable tabs** — tabs are named after the loaded file (stem); double-click to rename (a manual name sticks); "Untitled" when empty. The assay no longer renames tabs.
- **Wheel-scroll overflow** — when tabs overflow, the strip scrolls by mouse wheel (no chevron buttons); the inline `+` is preserved.

**Cross-platform:** verified headlessly (offscreen → Fusion); native macOS/Windows needs a final eyeball, with `QApplication.setStyle("Fusion")` as the sanctioned fallback if tabs render half-native.