### PR TITLE
feat: in-app forward simulation of titration data for experiment design

### DIFF
--- a/core/simulation.py
+++ b/core/simulation.py
@@ -1,0 +1,228 @@
+"""Forward simulation of titration data.
+
+This is the inverse of the fitting pipeline: given an assay, its conditions, and
+explicit parameter *values*, evaluate the **same forward model the fitter uses**
+over a chosen concentration vector — no fitting, no divergent math.  The GUI
+simulation applet uses this for experiment design (choosing concentration ranges,
+point counts, tolerable noise before bench time).
+
+All math is reused from :mod:`core.assays` / :mod:`core.models`; this module only
+builds the concentration grid, drives the assay's ``forward_model``, and optionally
+adds measurement noise.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence, Type
+
+import numpy as np
+
+from core.assays.base import BaseAssay
+from core.data_processing.measurement_set import MeasurementSet
+from core.units import Q_
+
+__all__ = ['build_concentration_vector', 'simulate_signal', 'simulate_dataset']
+
+
+def _as_count(n: Any) -> int:
+    """Coerce *n* to an int point-count of at least 2, else raise ``ValueError``."""
+    n_int = int(n)
+    if n_int < 2:
+        raise ValueError(f'Number of points must be at least 2 (got {n}).')
+    return n_int
+
+
+def build_concentration_vector(mode: str, **kwargs: Any) -> np.ndarray:
+    """Build a titrant concentration vector (Molar) from a chosen input mode.
+
+    Concentrations are physical quantities and **cannot be negative**; every mode
+    rejects ``x < 0`` (``x = 0`` is allowed — the forward models handle it).  All
+    inputs are interpreted in base units (Molar); unit conversion happens at the
+    GUI boundary.
+
+    Parameters
+    ----------
+    mode : str
+        One of ``'explicit'``, ``'linear'``, ``'step'``, ``'log'``.
+    **kwargs
+        Mode-specific arguments (all concentrations in M):
+
+        * ``explicit`` — ``values``: a sequence of concentrations.
+        * ``linear``   — ``start``, ``stop``, ``n``: ``np.linspace(start, stop, n)``.
+        * ``step``     — ``start``, ``step``, ``n``: ``start + step * arange(n)``.
+        * ``log``      — ``start``, ``stop``, ``n``: log-spaced from ``start`` to ``stop``.
+
+    Returns
+    -------
+    np.ndarray
+        1-D float array of concentrations in M.
+
+    Raises
+    ------
+    ValueError
+        On an unknown mode, ``n < 2``, ``stop <= start``, non-positive bounds for
+        log spacing, a non-positive step, an empty/non-finite vector, or any
+        negative concentration.
+    """
+    if mode == 'explicit':
+        values: Sequence[float] = kwargs['values']
+        arr = np.asarray(list(values), dtype=float)
+        if arr.size == 0:
+            raise ValueError('Concentration vector is empty — enter at least one value.')
+    elif mode == 'linear':
+        start, stop = float(kwargs['start']), float(kwargs['stop'])
+        if not stop > start:
+            raise ValueError(f'Linear range needs stop > start (got start={start:g}, stop={stop:g}).')
+        arr = np.linspace(start, stop, _as_count(kwargs['n']))
+    elif mode == 'step':
+        start, step = float(kwargs['start']), float(kwargs['step'])
+        if not step > 0:
+            raise ValueError(f'Step size must be positive (got {step:g}).')
+        arr = start + step * np.arange(_as_count(kwargs['n']))
+    elif mode == 'log':
+        start, stop = float(kwargs['start']), float(kwargs['stop'])
+        if not (start > 0 and stop > 0):
+            raise ValueError('Log spacing needs start > 0 and stop > 0.')
+        if not stop > start:
+            raise ValueError(f'Log range needs stop > start (got start={start:g}, stop={stop:g}).')
+        arr = np.logspace(np.log10(start), np.log10(stop), _as_count(kwargs['n']))
+    else:
+        raise ValueError(f'Unknown concentration mode: {mode!r}.')
+
+    if not np.all(np.isfinite(arr)):
+        raise ValueError('Concentration vector contains non-finite values.')
+    if np.any(arr < 0):
+        raise ValueError('Concentrations cannot be negative.')
+    return arr.astype(float)
+
+
+def _build_assay(
+    assay_cls: Type[BaseAssay],
+    conditions: Mapping[str, Any],
+    x_vector: np.ndarray,
+) -> BaseAssay:
+    """Construct an assay for forward evaluation over *x_vector* (M).
+
+    Mirrors :meth:`MeasurementSet.to_assay`: the titrant grid is ``x_data`` and the
+    (unused) ``y_data`` is a zero placeholder of matching shape.  ``conditions`` are
+    the same Quantity-valued kwargs ``AssayConfigPanel.current_conditions`` produces
+    (plus ``mode`` for DBA).
+    """
+    x = np.asarray(x_vector, dtype=float)
+    return assay_cls(
+        x_data=Q_(x, 'M'),
+        y_data=Q_(np.zeros_like(x), 'au'),
+        **conditions,
+    )
+
+
+def simulate_signal(
+    assay_cls: Type[BaseAssay],
+    conditions: Mapping[str, Any],
+    parameters: Mapping[str, float],
+    x_vector: np.ndarray,
+) -> np.ndarray:
+    """Evaluate an assay's forward model at *x_vector* from explicit parameters.
+
+    Uses the assay's own ``forward_model`` — identical to the fit path — so the
+    predicted signal is exactly what a fit with these parameters would reproduce.
+
+    Parameters
+    ----------
+    assay_cls : Type[BaseAssay]
+        Concrete assay class (e.g. ``GDAAssay``).
+    conditions : Mapping[str, Any]
+        Quantity-valued conditions (``Ka_dye``, ``h0``, ``fixed_conc``, …) plus
+        ``mode`` for DBA — as returned by ``AssayConfigPanel.current_conditions``.
+    parameters : Mapping[str, float]
+        Base-unit parameter values keyed by the assay's ``parameter_keys``.
+    x_vector : np.ndarray
+        Titrant concentrations (M).
+
+    Returns
+    -------
+    np.ndarray
+        Predicted signal (au) magnitudes, same length as *x_vector*.
+    """
+    assay = _build_assay(assay_cls, conditions, x_vector)
+    y = assay.forward_model(assay.params_from_dict(dict(parameters)))
+    return np.asarray(getattr(y, 'magnitude', y), dtype=float)
+
+
+def _signal_span(y: np.ndarray) -> float:
+    """Return a positive scale for noise: the signal's peak-to-peak range.
+
+    Falls back to the peak magnitude (then to 1.0) for flat curves so the noise
+    scale is never zero.
+    """
+    span = float(np.max(y) - np.min(y))
+    if span > 0:
+        return span
+    mag = float(np.max(np.abs(y)))
+    return mag if mag > 0 else 1.0
+
+
+def simulate_dataset(
+    assay_cls: Type[BaseAssay],
+    conditions: Mapping[str, Any],
+    parameters: Mapping[str, float],
+    x_vector: np.ndarray,
+    *,
+    noise_frac: float = 0.0,
+    n_replicas: int = 1,
+    rng: np.random.Generator | None = None,
+) -> MeasurementSet:
+    """Simulate a multi-replica :class:`MeasurementSet` from explicit parameters.
+
+    The clean signal is sampled at *x_vector*; when ``noise_frac > 0`` each replica
+    gets independent Gaussian noise with standard deviation
+    ``noise_frac × (signal peak-to-peak range)`` — a scale-invariant fraction, so
+    the same ``noise_frac`` is meaningful across assays with very different signal
+    magnitudes.
+
+    Parameters
+    ----------
+    noise_frac : float
+        Noise standard deviation as a fraction of the signal range (0 = clean).
+    n_replicas : int
+        Number of replicate rows (>= 1).
+    rng : np.random.Generator, optional
+        Source of randomness; defaults to ``np.random.default_rng()``.
+
+    Returns
+    -------
+    MeasurementSet
+        Loadable/fittable via the existing pipeline.  ``metadata`` records the
+        ground-truth parameters/conditions for provenance (note: the measurement
+        writers do not persist metadata — the settings JSON is the durable record).
+    """
+    assay = _build_assay(assay_cls, conditions, x_vector)
+    y = assay.forward_model(assay.params_from_dict(dict(parameters)))
+    y_clean = np.asarray(getattr(y, 'magnitude', y), dtype=float)
+
+    n_replicas = max(1, int(n_replicas))
+    x = np.asarray(x_vector, dtype=float)
+    if noise_frac and noise_frac > 0:
+        if rng is None:
+            rng = np.random.default_rng()
+        sd = float(noise_frac) * _signal_span(y_clean)
+        signals = y_clean[None, :] + rng.normal(0.0, sd, size=(n_replicas, x.size))
+    else:
+        signals = np.tile(y_clean, (n_replicas, 1))
+
+    cond_plain = {k: (float(v.magnitude) if hasattr(v, 'magnitude') else v) for k, v in conditions.items()}
+    metadata = {
+        'source_file': 'simulation',
+        'assay_type': assay.assay_type.name,
+        'simulation': {
+            'parameters': dict(parameters),
+            'conditions': cond_plain,
+            'noise_frac': float(noise_frac),
+        },
+    }
+    return MeasurementSet(
+        concentrations=x,
+        signals=signals,
+        replica_ids=tuple(f'sim{i + 1}' for i in range(n_replicas)),
+        metadata=metadata,
+    )

--- a/core/units.py
+++ b/core/units.py
@@ -22,6 +22,7 @@ import pint
 ureg = pint.UnitRegistry()
 Q_ = ureg.Quantity
 Quantity = pint.Quantity
+Unit = pint.Unit
 
 # Custom unit definitions
 ureg.define('micromolar = 1e-6 * molar = uM = µM')

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -99,6 +99,7 @@ class FittingMainWindow(QMainWindow):
     def __init__(self, parent=None):
         super().__init__(parent)
         self._update_worker: UpdateCheckWorker | None = None
+        self._sim_window: QMainWindow | None = None
         self._set_title()
         self.resize(1280, 820)
         self._setup_tabs()
@@ -184,6 +185,11 @@ class FittingMainWindow(QMainWindow):
         self._act_demo.setToolTip('Load bundled IDA demo data and run a fit with default settings')
         self._act_demo.triggered.connect(self._on_load_demo)
         tb.addAction(self._act_demo)
+
+        self._act_simulate = QAction('Simulate…', self)
+        self._act_simulate.setToolTip('Open the forward-simulation applet for experiment design (no data needed)')
+        self._act_simulate.triggered.connect(self._on_simulate)
+        tb.addAction(self._act_simulate)
 
         tb.addSeparator()
 
@@ -273,6 +279,7 @@ class FittingMainWindow(QMainWindow):
         file_menu.addAction(self._act_load)
         file_menu.addSeparator()
         file_menu.addAction(self._act_fit)
+        file_menu.addAction(self._act_simulate)
         file_menu.addSeparator()
         file_menu.addAction(self._act_export_all)
         file_menu.addSeparator()
@@ -354,6 +361,16 @@ class FittingMainWindow(QMainWindow):
         session = self.active_session()
         if session:
             session.load_demo_ida()
+
+    def _on_simulate(self) -> None:
+        """Open (or re-raise) the non-modal forward-simulation applet."""
+        if self._sim_window is None:
+            from gui.simulation.simulation_window import SimulationWindow
+
+            self._sim_window = SimulationWindow(self)
+        self._sim_window.show()
+        self._sim_window.raise_()
+        self._sim_window.activateWindow()
 
     def _on_run_fit(self) -> None:
         session = self.active_session()

--- a/gui/simulation/__init__.py
+++ b/gui/simulation/__init__.py
@@ -1,0 +1,6 @@
+"""In-app forward-simulation applet.
+
+A non-modal window for forward-modelling titration curves from chosen parameters
+(experiment design).  Pure forward simulation — no fitting.  All controls are
+registry-driven, so every assay plugs in with no bespoke UI.
+"""

--- a/gui/simulation/controls.py
+++ b/gui/simulation/controls.py
@@ -1,0 +1,453 @@
+"""Reusable live controls for the simulation applet.
+
+These are generic and assay-agnostic — they render whatever :class:`SimKnob` /
+concentration / noise configuration they are given, so the same widgets serve
+every assay.
+
+* :class:`ParameterControl` — one knob: a slider with user-editable [min, max]
+  bounds and an exact-value field.  Log slider for association constants, linear
+  otherwise; a nM/µM/mM/M selector for concentrations; negatives allowed for
+  signal coefficients (e.g. a calibration intercept).
+* :class:`ConcentrationInput` — the titrant vector, via explicit / linear /
+  start-step / log modes.
+* :class:`NoiseControl` — optional Gaussian measurement noise (fraction of the
+  signal range) with replicas and a seed.
+"""
+
+from __future__ import annotations
+
+import math
+
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QFormLayout,
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QSlider,
+    QWidget,
+)
+
+from core.units import Q_
+from gui.simulation.sim_knob import SimKnob
+from gui.widgets.numeric_inputs import NoScrollDoubleSpinBox, NoScrollSpinBox
+
+_SLIDER_STEPS = 1000
+
+# nM/µM/mM/M selector for concentration knobs/inputs (label → factor to Molar).
+_CONC_UNITS: list[tuple[str, float]] = [
+    ('nM', 1e-9),
+    ('µM', 1e-6),
+    ('mM', 1e-3),
+    ('M', 1.0),
+]
+_CONC_DEFAULT = 'µM'
+
+
+def _new_spin(*, decimals: int = 4, vmin: float = -1e15, vmax: float = 1e15) -> NoScrollDoubleSpinBox:
+    sb = NoScrollDoubleSpinBox()
+    sb.setDecimals(decimals)
+    sb.setRange(vmin, vmax)
+    sb.setKeyboardTracking(False)
+    sb.setMinimumWidth(96)
+    return sb
+
+
+class ParameterControl(QWidget):
+    """A single live knob: slider + editable bounds + exact value.
+
+    Internals are kept in **base units** (M / M⁻¹ / au / au·M⁻¹); for concentration
+    knobs a unit selector only rescales the *display*.  ``changed`` fires on every
+    user adjustment.
+    """
+
+    changed = pyqtSignal()
+
+    def __init__(self, knob: SimKnob, parent=None):
+        super().__init__(parent)
+        self._knob = knob
+        self._log = knob.log
+        self._value = float(knob.default)
+        self._vmin = float(knob.vmin)
+        self._vmax = float(knob.vmax)
+        self._scale = _unit_factor(_CONC_DEFAULT) if knob.kind == 'concentration' else 1.0
+
+        grid = QGridLayout(self)
+        grid.setContentsMargins(0, 2, 0, 6)
+        grid.setHorizontalSpacing(6)
+        grid.setVerticalSpacing(2)
+
+        # Row 0: label, value, unit (combo for concentration, static label else).
+        name = QLabel(knob.label)
+        name.setTextFormat(Qt.TextFormat.RichText)
+        name.setToolTip(knob.tooltip)
+        self._value_spin = _new_spin()
+        self._value_spin.setToolTip(knob.tooltip)
+        grid.addWidget(name, 0, 0)
+        grid.addWidget(self._value_spin, 0, 1)
+        if knob.kind == 'concentration':
+            self._unit_combo: QComboBox | None = QComboBox()
+            for label, _ in _CONC_UNITS:
+                self._unit_combo.addItem(label)
+            self._unit_combo.setCurrentText(_CONC_DEFAULT)
+            self._unit_combo.currentTextChanged.connect(self._on_unit_changed)
+            grid.addWidget(self._unit_combo, 0, 2)
+        else:
+            self._unit_combo = None
+            grid.addWidget(QLabel(knob.unit), 0, 2)
+
+        # Row 1: min, slider, max.
+        self._min_spin = _new_spin(vmin=(0.0 if knob.kind != 'signal' else -1e15))
+        self._max_spin = _new_spin(vmin=(0.0 if knob.kind != 'signal' else -1e15))
+        self._slider = QSlider(Qt.Orientation.Horizontal)
+        self._slider.setRange(0, _SLIDER_STEPS)
+        grid.addWidget(self._min_spin, 1, 0)
+        grid.addWidget(self._slider, 1, 1)
+        grid.addWidget(self._max_spin, 1, 2)
+
+        self._sync_all()
+
+        self._slider.valueChanged.connect(self._on_slider)
+        self._value_spin.valueChanged.connect(self._on_value_edit)
+        self._min_spin.valueChanged.connect(self._on_bounds_edit)
+        self._max_spin.valueChanged.connect(self._on_bounds_edit)
+
+    # -- public API ----------------------------------------------------------
+
+    def value(self) -> float:
+        """Current value in the base unit (M / M⁻¹ / au / au·M⁻¹)."""
+        return self._value
+
+    def quantity(self):
+        """Current value as a pint Quantity (for assay conditions)."""
+        return Q_(self._value, self._knob.unit)
+
+    def state(self) -> dict:
+        """Serializable knob state for settings save."""
+        return {'value': self._value, 'min': self._vmin, 'max': self._vmax}
+
+    def load_state(self, state: dict) -> None:
+        self._vmin = float(state.get('min', self._vmin))
+        self._vmax = float(state.get('max', self._vmax))
+        self._value = _clamp(float(state.get('value', self._value)), self._vmin, self._vmax)
+        self._sync_all()
+        self.changed.emit()
+
+    # -- slider <-> value mapping -------------------------------------------
+
+    def _pos_to_value(self, pos: int) -> float:
+        f = pos / _SLIDER_STEPS
+        if self._log and self._vmin > 0 and self._vmax > self._vmin:
+            lo, hi = math.log10(self._vmin), math.log10(self._vmax)
+            return 10 ** (lo + f * (hi - lo))
+        return self._vmin + f * (self._vmax - self._vmin)
+
+    def _value_to_pos(self, v: float) -> int:
+        if self._vmax <= self._vmin:
+            return 0
+        if self._log and self._vmin > 0 and self._vmax > self._vmin:
+            lo, hi = math.log10(self._vmin), math.log10(self._vmax)
+            f = (math.log10(max(v, self._vmin)) - lo) / (hi - lo)
+        else:
+            f = (v - self._vmin) / (self._vmax - self._vmin)
+        return int(round(_clamp(f, 0.0, 1.0) * _SLIDER_STEPS))
+
+    # -- sync helpers (block signals to avoid feedback loops) ---------------
+
+    def _sync_all(self) -> None:
+        self._sync_bounds_spins()
+        self._sync_value_spin()
+        self._sync_slider()
+
+    def _sync_value_spin(self) -> None:
+        self._value_spin.blockSignals(True)
+        self._value_spin.setValue(self._value / self._scale)
+        self._value_spin.blockSignals(False)
+
+    def _sync_bounds_spins(self) -> None:
+        for sb, val in ((self._min_spin, self._vmin), (self._max_spin, self._vmax)):
+            sb.blockSignals(True)
+            sb.setValue(val / self._scale)
+            sb.blockSignals(False)
+
+    def _sync_slider(self) -> None:
+        self._slider.blockSignals(True)
+        self._slider.setValue(self._value_to_pos(self._value))
+        self._slider.blockSignals(False)
+
+    # -- slots ---------------------------------------------------------------
+
+    def _on_slider(self, pos: int) -> None:
+        self._value = self._pos_to_value(pos)
+        self._sync_value_spin()
+        self.changed.emit()
+
+    def _on_value_edit(self, shown: float) -> None:
+        self._value = _clamp(shown * self._scale, self._vmin, self._vmax)
+        self._sync_slider()
+        self.changed.emit()
+
+    def _on_bounds_edit(self) -> None:
+        vmin = self._min_spin.value() * self._scale
+        vmax = self._max_spin.value() * self._scale
+        if self._log:
+            vmin = max(vmin, 1e-12)  # log slider needs a positive floor
+        if vmax <= vmin:
+            vmax = vmin * 10 if self._log else vmin + abs(vmin or 1.0)
+        self._vmin, self._vmax = vmin, vmax
+        self._value = _clamp(self._value, vmin, vmax)
+        self._sync_all()
+        self.changed.emit()
+
+    def _on_unit_changed(self, label: str) -> None:
+        self._scale = _unit_factor(label)
+        self._sync_value_spin()
+        self._sync_bounds_spins()
+
+
+class ConcentrationInput(QWidget):
+    """Titrant concentration vector with selectable input modes.
+
+    ``spec()`` returns ``(mode, kwargs)`` (concentrations in M) ready for
+    :func:`core.simulation.build_concentration_vector`.
+    """
+
+    changed = pyqtSignal()
+
+    _MODES = [
+        ('Linear (start, stop, N)', 'linear'),
+        ('Start, step, N', 'step'),
+        ('Log (start, stop, N)', 'log'),
+        ('Explicit vector', 'explicit'),
+    ]
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._scale = _unit_factor(_CONC_DEFAULT)
+
+        form = QFormLayout(self)
+        form.setContentsMargins(0, 0, 0, 0)
+
+        self._mode = QComboBox()
+        for label, key in self._MODES:
+            self._mode.addItem(label, userData=key)
+        self._mode.currentIndexChanged.connect(self._on_mode_changed)
+
+        self._unit = QComboBox()
+        for label, _ in _CONC_UNITS:
+            self._unit.addItem(label)
+        self._unit.setCurrentText(_CONC_DEFAULT)
+        self._unit.currentTextChanged.connect(self._on_unit_changed)
+        mode_row = QWidget()
+        mr = QHBoxLayout(mode_row)
+        mr.setContentsMargins(0, 0, 0, 0)
+        mr.addWidget(self._mode, 1)
+        mr.addWidget(self._unit)
+        form.addRow('Mode', mode_row)
+
+        self._start = _new_spin(vmin=0.0)
+        self._stop = _new_spin(vmin=0.0)
+        self._step = _new_spin(vmin=0.0)
+        self._n = NoScrollSpinBox()
+        self._n.setRange(2, 100000)
+        self._n.setValue(11)
+        self._explicit = QLineEdit()
+        self._explicit.setPlaceholderText('e.g. 0, 1, 2.5, 5, 10')
+
+        # Rows are shown/hidden per mode.
+        self._row_start = self._add_row(form, 'Start', self._start)
+        self._row_stop = self._add_row(form, 'Stop', self._stop)
+        self._row_step = self._add_row(form, 'Step', self._step)
+        self._row_n = self._add_row(form, 'Points (N)', self._n)
+        self._row_explicit = self._add_row(form, 'Values', self._explicit)
+
+        for sb in (self._start, self._stop, self._step):
+            sb.valueChanged.connect(self.changed)
+        self._n.valueChanged.connect(self.changed)
+        self._explicit.textChanged.connect(self.changed)
+
+        self._apply_mode_visibility('linear')
+
+    @staticmethod
+    def _add_row(form: QFormLayout, label: str, w: QWidget):
+        lbl = QLabel(label)
+        form.addRow(lbl, w)
+        return (lbl, w)
+
+    def current_mode(self) -> str:
+        return self._mode.currentData()
+
+    def set_linear(self, start_m: float, stop_m: float, n: int) -> None:
+        """Programmatically set a linear range (Molar). Used on assay change."""
+        self._mode.blockSignals(True)
+        self._mode.setCurrentIndex(0)
+        self._mode.blockSignals(False)
+        self._apply_mode_visibility('linear')
+        for sb, val in ((self._start, start_m), (self._stop, stop_m)):
+            sb.blockSignals(True)
+            sb.setValue(val / self._scale)
+            sb.blockSignals(False)
+        self._n.blockSignals(True)
+        self._n.setValue(int(n))
+        self._n.blockSignals(False)
+        self.changed.emit()
+
+    def spec(self) -> tuple[str, dict]:
+        mode = self.current_mode()
+        s = self._scale
+        if mode == 'linear':
+            return mode, {'start': self._start.value() * s, 'stop': self._stop.value() * s, 'n': self._n.value()}
+        if mode == 'step':
+            return mode, {'start': self._start.value() * s, 'step': self._step.value() * s, 'n': self._n.value()}
+        if mode == 'log':
+            return mode, {'start': self._start.value() * s, 'stop': self._stop.value() * s, 'n': self._n.value()}
+        return mode, {'values': [v * s for v in _parse_floats(self._explicit.text())]}
+
+    def load_spec(self, mode: str, kwargs: dict) -> None:
+        idx = next((i for i, (_, k) in enumerate(self._MODES) if k == mode), 0)
+        self._mode.blockSignals(True)
+        self._mode.setCurrentIndex(idx)
+        self._mode.blockSignals(False)
+        self._apply_mode_visibility(mode)
+        s = self._scale
+        if mode in ('linear', 'log'):
+            self._set_silent(self._start, kwargs.get('start', 0.0) / s)
+            self._set_silent(self._stop, kwargs.get('stop', 0.0) / s)
+            self._set_n(kwargs.get('n', 11))
+        elif mode == 'step':
+            self._set_silent(self._start, kwargs.get('start', 0.0) / s)
+            self._set_silent(self._step, kwargs.get('step', 0.0) / s)
+            self._set_n(kwargs.get('n', 11))
+        else:
+            self._explicit.blockSignals(True)
+            self._explicit.setText(', '.join(f'{v / s:g}' for v in kwargs.get('values', [])))
+            self._explicit.blockSignals(False)
+        self.changed.emit()
+
+    # -- internals -----------------------------------------------------------
+
+    @staticmethod
+    def _set_silent(sb: NoScrollDoubleSpinBox, val: float) -> None:
+        sb.blockSignals(True)
+        sb.setValue(val)
+        sb.blockSignals(False)
+
+    def _set_n(self, n) -> None:
+        self._n.blockSignals(True)
+        self._n.setValue(int(n))
+        self._n.blockSignals(False)
+
+    def _on_mode_changed(self) -> None:
+        self._apply_mode_visibility(self.current_mode())
+        self.changed.emit()
+
+    def _on_unit_changed(self) -> None:
+        self._scale = _unit_factor(self._unit.currentText())
+        self.changed.emit()
+
+    def _apply_mode_visibility(self, mode: str) -> None:
+        show = {
+            'linear': {'start', 'stop', 'n'},
+            'step': {'start', 'step', 'n'},
+            'log': {'start', 'stop', 'n'},
+            'explicit': {'explicit'},
+        }[mode]
+        for key, (lbl, w) in {
+            'start': self._row_start,
+            'stop': self._row_stop,
+            'step': self._row_step,
+            'n': self._row_n,
+            'explicit': self._row_explicit,
+        }.items():
+            visible = key in show
+            lbl.setVisible(visible)
+            w.setVisible(visible)
+
+
+class NoiseControl(QWidget):
+    """Optional Gaussian measurement noise: enable, fraction-of-range, replicas, seed."""
+
+    changed = pyqtSignal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        form = QFormLayout(self)
+        form.setContentsMargins(0, 0, 0, 0)
+
+        self._enable = QCheckBox('Add measurement noise')
+        self._enable.toggled.connect(self._on_toggle)
+        form.addRow(self._enable)
+
+        self._frac = NoScrollDoubleSpinBox()
+        self._frac.setRange(0.0, 100.0)
+        self._frac.setDecimals(2)
+        self._frac.setValue(5.0)
+        self._frac.setSuffix(' %')
+        self._frac.valueChanged.connect(self.changed)
+        form.addRow('Noise', self._frac)
+
+        self._replicas = NoScrollSpinBox()
+        self._replicas.setRange(1, 50)
+        self._replicas.setValue(3)
+        self._replicas.valueChanged.connect(self.changed)
+        form.addRow('Replicas', self._replicas)
+
+        self._seed = NoScrollSpinBox()
+        self._seed.setRange(0, 1_000_000)
+        self._seed.setValue(0)
+        self._seed.valueChanged.connect(self.changed)
+        form.addRow('Seed', self._seed)
+
+        self._on_toggle(False)
+
+    def _on_toggle(self, on: bool) -> None:
+        for w in (self._frac, self._replicas, self._seed):
+            w.setEnabled(on)
+        self.changed.emit()
+
+    def settings(self) -> dict:
+        return {
+            'enabled': self._enable.isChecked(),
+            'frac': self._frac.value() / 100.0,
+            'replicas': self._replicas.value(),
+            'seed': self._seed.value(),
+        }
+
+    def load_settings(self, s: dict) -> None:
+        for w, val in (
+            (self._enable, bool(s.get('enabled', False))),
+            (self._frac, float(s.get('frac', 0.05)) * 100.0),
+            (self._replicas, int(s.get('replicas', 3))),
+            (self._seed, int(s.get('seed', 0))),
+        ):
+            w.blockSignals(True)
+            w.setChecked(val) if w is self._enable else w.setValue(val)
+            w.blockSignals(False)
+        self._on_toggle(self._enable.isChecked())
+
+
+# ---------------------------------------------------------------------------
+# Module helpers
+# ---------------------------------------------------------------------------
+
+
+def _unit_factor(label: str) -> float:
+    return next((f for lbl, f in _CONC_UNITS if lbl == label), 1.0)
+
+
+def _clamp(v: float, lo: float, hi: float) -> float:
+    return max(lo, min(hi, v))
+
+
+def _parse_floats(text: str) -> list[float]:
+    """Parse a comma/space-separated list of floats; raise ValueError if any token is bad."""
+    tokens = [t for t in text.replace(',', ' ').split() if t]
+    if not tokens:
+        return []
+    try:
+        return [float(t) for t in tokens]
+    except ValueError as exc:
+        raise ValueError(f'Invalid concentration value in: {text!r}') from exc

--- a/gui/simulation/controls.py
+++ b/gui/simulation/controls.py
@@ -37,13 +37,10 @@ from gui.widgets.numeric_inputs import NoScrollDoubleSpinBox, NoScrollSpinBox
 
 _SLIDER_STEPS = 1000
 
-# nM/µM/mM/M selector for concentration knobs/inputs (label → factor to Molar).
-_CONC_UNITS: list[tuple[str, float]] = [
-    ('nM', 1e-9),
-    ('µM', 1e-6),
-    ('mM', 1e-3),
-    ('M', 1.0),
-]
+# nM/µM/mM/M selector for concentration knobs/inputs.  The label set is a UI
+# choice; the conversion factors are always derived from Pint (_display_factor),
+# never hardcoded.
+_CONC_LABELS: tuple[str, ...] = ('nM', 'µM', 'mM', 'M')
 _CONC_DEFAULT = 'µM'
 
 
@@ -73,7 +70,7 @@ class ParameterControl(QWidget):
         self._value = float(knob.default)
         self._vmin = float(knob.vmin)
         self._vmax = float(knob.vmax)
-        self._scale = _unit_factor(_CONC_DEFAULT) if knob.kind == 'concentration' else 1.0
+        self._scale = _display_factor(_CONC_DEFAULT, knob.unit) if knob.is_concentration else 1.0
 
         grid = QGridLayout(self)
         grid.setContentsMargins(0, 2, 0, 6)
@@ -88,20 +85,21 @@ class ParameterControl(QWidget):
         self._value_spin.setToolTip(knob.tooltip)
         grid.addWidget(name, 0, 0)
         grid.addWidget(self._value_spin, 0, 1)
-        if knob.kind == 'concentration':
+        if knob.is_concentration:
             self._unit_combo: QComboBox | None = QComboBox()
-            for label, _ in _CONC_UNITS:
-                self._unit_combo.addItem(label)
+            self._unit_combo.addItems(list(_CONC_LABELS))
             self._unit_combo.setCurrentText(_CONC_DEFAULT)
             self._unit_combo.currentTextChanged.connect(self._on_unit_changed)
             grid.addWidget(self._unit_combo, 0, 2)
         else:
             self._unit_combo = None
-            grid.addWidget(QLabel(knob.unit), 0, 2)
+            grid.addWidget(QLabel(f'{knob.unit:~P}'), 0, 2)
 
-        # Row 1: min, slider, max.
-        self._min_spin = _new_spin(vmin=(0.0 if knob.kind != 'signal' else -1e15))
-        self._max_spin = _new_spin(vmin=(0.0 if knob.kind != 'signal' else -1e15))
+        # Row 1: min, slider, max.  Concentrations/association constants stay ≥ 0;
+        # signal coefficients (incl. a calibration intercept) may go negative.
+        floor = -1e15 if knob.allows_negative else 0.0
+        self._min_spin = _new_spin(vmin=floor)
+        self._max_spin = _new_spin(vmin=floor)
         self._slider = QSlider(Qt.Orientation.Horizontal)
         self._slider.setRange(0, _SLIDER_STEPS)
         grid.addWidget(self._min_spin, 1, 0)
@@ -203,7 +201,7 @@ class ParameterControl(QWidget):
         self.changed.emit()
 
     def _on_unit_changed(self, label: str) -> None:
-        self._scale = _unit_factor(label)
+        self._scale = _display_factor(label, self._knob.unit)
         self._sync_value_spin()
         self._sync_bounds_spins()
 
@@ -226,7 +224,8 @@ class ConcentrationInput(QWidget):
 
     def __init__(self, parent=None):
         super().__init__(parent)
-        self._scale = _unit_factor(_CONC_DEFAULT)
+        # The titrant vector is always Molar; the selector only rescales the display.
+        self._scale = _display_factor(_CONC_DEFAULT, 'M')
 
         form = QFormLayout(self)
         form.setContentsMargins(0, 0, 0, 0)
@@ -237,8 +236,7 @@ class ConcentrationInput(QWidget):
         self._mode.currentIndexChanged.connect(self._on_mode_changed)
 
         self._unit = QComboBox()
-        for label, _ in _CONC_UNITS:
-            self._unit.addItem(label)
+        self._unit.addItems(list(_CONC_LABELS))
         self._unit.setCurrentText(_CONC_DEFAULT)
         self._unit.currentTextChanged.connect(self._on_unit_changed)
         mode_row = QWidget()
@@ -345,7 +343,7 @@ class ConcentrationInput(QWidget):
         self.changed.emit()
 
     def _on_unit_changed(self) -> None:
-        self._scale = _unit_factor(self._unit.currentText())
+        self._scale = _display_factor(self._unit.currentText(), 'M')
         self.changed.emit()
 
     def _apply_mode_visibility(self, mode: str) -> None:
@@ -434,8 +432,13 @@ class NoiseControl(QWidget):
 # ---------------------------------------------------------------------------
 
 
-def _unit_factor(label: str) -> float:
-    return next((f for lbl, f in _CONC_UNITS if lbl == label), 1.0)
+def _display_factor(label: str, base) -> float:
+    """Pint-derived scale: magnitude of ``1 <label>`` expressed in ``base`` units.
+
+    ``base`` is a pint ``Unit`` (a knob's canonical unit) or a unit string. The
+    shared registry (``core.units``) is the single source of every factor.
+    """
+    return float(Q_(1, label).to(base).magnitude)
 
 
 def _clamp(v: float, lo: float, hi: float) -> float:

--- a/gui/simulation/settings_io.py
+++ b/gui/simulation/settings_io.py
@@ -1,0 +1,23 @@
+"""Save / load simulation applet settings as JSON.
+
+The settings dict (from ``SimulationPanel.state``) is the durable provenance
+record for a simulation: assay, every knob's value + bounds, the concentration
+spec, and noise settings.  (The measurement writers do not persist metadata, so
+this — not the exported data file — is where the ground-truth parameters live.)
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def save_simulation_settings(state: dict[str, Any], path: str | Path) -> None:
+    """Write *state* (from :meth:`SimulationPanel.state`) to a JSON file."""
+    Path(path).write_text(json.dumps(state, indent=2), encoding='utf-8')
+
+
+def load_simulation_settings(path: str | Path) -> dict[str, Any]:
+    """Read a settings dict previously written by :func:`save_simulation_settings`."""
+    return json.loads(Path(path).read_text(encoding='utf-8'))

--- a/gui/simulation/sim_knob.py
+++ b/gui/simulation/sim_knob.py
@@ -7,9 +7,14 @@ condition vs a parameter (that differs across assays: ``Ka_dye`` is a condition
 for GDA/IDA but a parameter for DBA).  The categorical DBA ``mode`` is not a knob;
 it is derived from the assay subtype where the spec is assembled.
 
-A knob's *kind* drives its control: ``binding`` (association constant → log slider,
-``M⁻¹``), ``concentration`` (→ linear slider, ``M``, with a nM/µM/mM/M selector),
-or ``signal`` (signal coefficient → linear slider, ``au`` / ``au·M⁻¹``).
+Each knob carries its **canonical Pint unit** (from the registry), so display,
+dimensionality, and unit conversions all go through Pint / ``core.units`` — never a
+hand-rolled token or hardcoded factor.  From the unit we derive whether the knob is
+a concentration (→ nM/µM/mM/M selector) and whether it may be negative.  Whether it
+is *log*-scaled is a modelling fact read from the registry: because ``au`` is
+dimensionless, a signal coefficient ``au/M`` is dimensionally identical to a binding
+constant ``1/M``, so dimensionality cannot tell them apart — ``log_scale_keys`` /
+``unit_type`` can.
 """
 
 from __future__ import annotations
@@ -17,7 +22,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from core.assays.registry import ASSAY_REGISTRY, AssayType
+from core.units import Q_, Unit
 from gui.widgets.assay_conditions import condition_fields
+
+# Dimensionality shared by every concentration unit (M, µM, nM, …).
+_MOLAR_DIM = Q_(1, 'M').dimensionality
 
 
 @dataclass(frozen=True)
@@ -27,17 +36,23 @@ class SimKnob:
     key: str
     label: str  # HTML, e.g. 'K<sub>a,guest</sub>'
     tooltip: str
-    kind: str  # 'binding' | 'concentration' | 'signal'
-    unit: str  # base-unit token: 'M⁻¹' | 'M' | 'au' | 'au/M'
-    default: float  # in base unit
+    unit: Unit  # canonical Pint unit from the registry
+    log: bool  # association constant → log slider (registry-declared)
+    default: float  # magnitude in `unit`
     vmin: float
     vmax: float
     is_condition: bool
 
     @property
-    def log(self) -> bool:
-        """Association constants get a log slider; everything else is linear."""
-        return self.kind == 'binding'
+    def is_concentration(self) -> bool:
+        """Molar-dimensioned knobs get a nM/µM/mM/M selector (Pint dimensionality)."""
+        return self.unit.dimensionality == _MOLAR_DIM
+
+    @property
+    def allows_negative(self) -> bool:
+        """Concentrations and association constants are strictly positive; signal
+        coefficients (au, au·M⁻¹ — e.g. a calibration intercept) may be negative."""
+        return not (self.log or self.is_concentration)
 
 
 @dataclass(frozen=True)
@@ -87,27 +102,20 @@ TITRANT_RANGE: dict[AssayType, tuple[float, float]] = {
 }
 
 
-def slider_bounds(default: float, kind: str) -> tuple[float, float]:
+def slider_bounds(default: float, log: bool) -> tuple[float, float]:
     """Default slider range for a *condition* knob, derived from its default.
 
-    Concentration: ``0 .. 5×default``.  Binding (Ka): three decades either side.
-    Never derived from the registry fit search bounds.  Signal knobs are all
-    parameters and carry explicit ranges in :data:`SIM_PARAM_DEFAULTS` instead
-    (a signal coefficient has no natural scale derivable from a single default —
-    e.g. ``I_H`` defaults to 0).
+    Association constant (``log``): three decades either side.  Concentration:
+    ``0 .. 5×default``.  Never derived from the registry fit search bounds.  Signal
+    knobs are all parameters and carry explicit ranges in :data:`SIM_PARAM_DEFAULTS`
+    instead (a signal coefficient has no natural scale derivable from a single
+    default — e.g. ``I_H`` defaults to 0).
     """
-    if kind == 'binding':
+    if log:
         d = default if default > 0 else 1e6
         return (d / 1e3, d * 1e3)
-    if kind == 'concentration':
-        d = default if default > 0 else 1e-5
-        return (0.0, d * 5)
-    raise ValueError(f"slider_bounds expects 'binding'/'concentration', got {kind!r}")
-
-
-def _signal_unit(pint_units: str) -> str:
-    """Map a registry unit string to a short token: 'au / molar' → 'au/M'."""
-    return 'au/M' if 'molar' in pint_units else 'au'
+    d = default if default > 0 else 1e-5
+    return (0.0, d * 5)
 
 
 def knobs_for(assay_type: AssayType) -> list[SimKnob]:
@@ -116,20 +124,20 @@ def knobs_for(assay_type: AssayType) -> list[SimKnob]:
     knobs: list[SimKnob] = []
 
     for f in condition_fields(assay_type):
-        kind = 'binding' if f.unit_type == 'binding_constant' else 'concentration'
-        unit = 'M⁻¹' if kind == 'binding' else 'M'
-        vmin, vmax = slider_bounds(f.default, kind)
-        knobs.append(SimKnob(f.key, f.label, f.tooltip, kind, unit, f.default, vmin, vmax, is_condition=True))
+        log = f.unit_type == 'binding_constant'
+        unit = Q_(1, f.unit).units
+        vmin, vmax = slider_bounds(f.default, log)
+        knobs.append(SimKnob(f.key, f.label, f.tooltip, unit, log, f.default, vmin, vmax, is_condition=True))
 
     units = meta.units
     for key in meta.parameter_keys:
         if key not in SIM_PARAM_DEFAULTS:
             raise KeyError(f'No simulation default for parameter {key!r}; add it to SIM_PARAM_DEFAULTS.')
         spec = SIM_PARAM_DEFAULTS[key]
-        kind = 'binding' if key in meta.log_scale_keys else 'signal'
-        unit = 'M⁻¹' if kind == 'binding' else _signal_unit(units.get(key, 'au'))
+        log = key in meta.log_scale_keys
+        unit = Q_(1, units[key]).units
         knobs.append(
-            SimKnob(key, spec.label, spec.tooltip, kind, unit, spec.default, spec.vmin, spec.vmax, is_condition=False)
+            SimKnob(key, spec.label, spec.tooltip, unit, log, spec.default, spec.vmin, spec.vmax, is_condition=False)
         )
 
     return knobs

--- a/gui/simulation/sim_knob.py
+++ b/gui/simulation/sim_knob.py
@@ -1,0 +1,135 @@
+"""Registry-driven knob model for the simulation applet.
+
+A *knob* is one live, user-adjustable numeric input.  For a given assay the full
+knob set is, mechanically, its conditions (``condition_fields``) plus its model
+parameters (``parameter_keys``) — with **no assumption** about which Ka is a
+condition vs a parameter (that differs across assays: ``Ka_dye`` is a condition
+for GDA/IDA but a parameter for DBA).  The categorical DBA ``mode`` is not a knob;
+it is derived from the assay subtype where the spec is assembled.
+
+A knob's *kind* drives its control: ``binding`` (association constant → log slider,
+``M⁻¹``), ``concentration`` (→ linear slider, ``M``, with a nM/µM/mM/M selector),
+or ``signal`` (signal coefficient → linear slider, ``au`` / ``au·M⁻¹``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from core.assays.registry import ASSAY_REGISTRY, AssayType
+from gui.widgets.assay_conditions import condition_fields
+
+
+@dataclass(frozen=True)
+class SimKnob:
+    """One live numeric control: a value plus a user-adjustable [vmin, vmax]."""
+
+    key: str
+    label: str  # HTML, e.g. 'K<sub>a,guest</sub>'
+    tooltip: str
+    kind: str  # 'binding' | 'concentration' | 'signal'
+    unit: str  # base-unit token: 'M⁻¹' | 'M' | 'au' | 'au/M'
+    default: float  # in base unit
+    vmin: float
+    vmax: float
+    is_condition: bool
+
+    @property
+    def log(self) -> bool:
+        """Association constants get a log slider; everything else is linear."""
+        return self.kind == 'binding'
+
+
+@dataclass(frozen=True)
+class _ParamSpec:
+    label: str
+    tooltip: str
+    default: float
+    vmin: float
+    vmax: float
+
+
+# Default model-parameter values + slider ranges, keyed by parameter name.
+# Defaults are seeded from the proven ground truth in tests/conftest.py so each
+# assay opens on a visibly-shaped curve.  Ranges are sensible *simulation* spans —
+# deliberately NOT the registry ``default_bounds`` (those are 20+-decade fit search
+# ranges, and ``I_H`` is pinned to a zero-width ``(0, 0)`` there).
+SIM_PARAM_DEFAULTS: dict[str, _ParamSpec] = {
+    'Ka_guest': _ParamSpec('K<sub>a,guest</sub>', 'Host–guest association constant', 1e6, 1e3, 1e9),
+    'Ka_dye': _ParamSpec('K<sub>a,dye</sub>', 'Host–dye association constant', 5e5, 1e3, 1e9),
+    'Ka_HG': _ParamSpec('K<sub>a,HG</sub>', 'First stepwise association constant', 1e6, 1e3, 1e9),
+    'Ka_HG2': _ParamSpec('K<sub>a,HG₂</sub>', 'Second stepwise constant (host binds two guests)', 2e5, 1e3, 1e9),
+    'Ka_H2G': _ParamSpec('K<sub>a,H₂G</sub>', 'Second stepwise constant (two hosts bind one guest)', 2e5, 1e3, 1e9),
+    'I0': _ParamSpec('I<sub>0</sub>', 'Baseline signal offset', 0.0, -1e3, 1e3),
+    'I_dye_free': _ParamSpec('I<sub>dye,free</sub>', 'Signal per unit free dye', 5e7, 0.0, 5e8),
+    'I_dye_bound': _ParamSpec('I<sub>dye,bound</sub>', 'Signal per unit host–dye complex', 3e8, 0.0, 1e9),
+    'I_G': _ParamSpec('I<sub>G</sub>', 'Signal per unit free guest', 1e6, 0.0, 1e8),
+    'I_H': _ParamSpec('I<sub>H</sub>', 'Signal per unit free host', 0.0, 0.0, 1e8),
+    'I_HG': _ParamSpec('I<sub>HG</sub>', 'Signal per unit HG complex', 1e7, 0.0, 1e8),
+    'I_HG2': _ParamSpec('I<sub>HG₂</sub>', 'Signal per unit HG₂ complex', 5e6, 0.0, 1e8),
+    'I_H2G': _ParamSpec('I<sub>H₂G</sub>', 'Signal per unit H₂G complex', 5e6, 0.0, 1e8),
+    'slope': _ParamSpec('slope', 'Linear calibration slope', 5e10, 0.0, 1e11),
+    'intercept': _ParamSpec('intercept', 'Linear calibration intercept', 100.0, -1e4, 1e4),
+}
+
+
+# Sensible default titration range per assay (start, stop in Molar), matching the
+# species each assay titrates and the ranges used by the synthetic generators in
+# tests/conftest.py — so the applet opens on a well-framed transition.
+TITRANT_RANGE: dict[AssayType, tuple[float, float]] = {
+    AssayType.GDA: (0.0, 30e-6),
+    AssayType.IDA: (0.0, 50e-6),
+    AssayType.DBA_HtoD: (0.0, 50e-6),
+    AssayType.DBA_DtoH: (0.0, 50e-6),
+    AssayType.DYE_ALONE: (0.0, 20e-6),
+    AssayType.DBA_HG2: (0.0, 1.2e-3),
+    AssayType.DBA_H2G: (0.0, 6e-4),
+}
+
+
+def slider_bounds(default: float, kind: str) -> tuple[float, float]:
+    """Default slider range for a *condition* knob, derived from its default.
+
+    Concentration: ``0 .. 5×default``.  Binding (Ka): three decades either side.
+    Never derived from the registry fit search bounds.  Signal knobs are all
+    parameters and carry explicit ranges in :data:`SIM_PARAM_DEFAULTS` instead
+    (a signal coefficient has no natural scale derivable from a single default —
+    e.g. ``I_H`` defaults to 0).
+    """
+    if kind == 'binding':
+        d = default if default > 0 else 1e6
+        return (d / 1e3, d * 1e3)
+    if kind == 'concentration':
+        d = default if default > 0 else 1e-5
+        return (0.0, d * 5)
+    raise ValueError(f"slider_bounds expects 'binding'/'concentration', got {kind!r}")
+
+
+def _signal_unit(pint_units: str) -> str:
+    """Map a registry unit string to a short token: 'au / molar' → 'au/M'."""
+    return 'au/M' if 'molar' in pint_units else 'au'
+
+
+def knobs_for(assay_type: AssayType) -> list[SimKnob]:
+    """Return the full live-knob list for *assay_type*: conditions ∪ parameters."""
+    meta = ASSAY_REGISTRY[assay_type]
+    knobs: list[SimKnob] = []
+
+    for f in condition_fields(assay_type):
+        kind = 'binding' if f.unit_type == 'binding_constant' else 'concentration'
+        unit = 'M⁻¹' if kind == 'binding' else 'M'
+        vmin, vmax = slider_bounds(f.default, kind)
+        knobs.append(SimKnob(f.key, f.label, f.tooltip, kind, unit, f.default, vmin, vmax, is_condition=True))
+
+    units = meta.units
+    for key in meta.parameter_keys:
+        if key not in SIM_PARAM_DEFAULTS:
+            raise KeyError(f'No simulation default for parameter {key!r}; add it to SIM_PARAM_DEFAULTS.')
+        spec = SIM_PARAM_DEFAULTS[key]
+        kind = 'binding' if key in meta.log_scale_keys else 'signal'
+        unit = 'M⁻¹' if kind == 'binding' else _signal_unit(units.get(key, 'au'))
+        knobs.append(
+            SimKnob(key, spec.label, spec.tooltip, kind, unit, spec.default, spec.vmin, spec.vmax, is_condition=False)
+        )
+
+    return knobs

--- a/gui/simulation/simulation_panel.py
+++ b/gui/simulation/simulation_panel.py
@@ -1,0 +1,161 @@
+"""SimulationPanel — the registry-driven control stack for one assay.
+
+Rebuilds its knob controls entirely from ``knobs_for(assay_type)`` whenever the
+assay changes, then assembles a :class:`SimSpec` (everything
+:mod:`core.simulation` needs) from the live control values.  Knows nothing
+assay-specific beyond the registries.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Type
+
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtWidgets import QGroupBox, QLabel, QVBoxLayout, QWidget
+
+from core.assays.base import BaseAssay
+from core.assays.registry import ASSAY_REGISTRY, AssayType
+from gui.simulation.controls import ConcentrationInput, NoiseControl, ParameterControl
+from gui.simulation.sim_knob import TITRANT_RANGE, knobs_for
+from gui.widgets.assay_conditions import assay_class
+
+_DEFAULT_N = 11
+
+# DBA carries a categorical titration mode that is NOT a knob — it is fixed by the
+# chosen subtype, exactly as AssayConfigPanel.current_conditions injects it.
+_DBA_MODE = {AssayType.DBA_HtoD: 'HtoD', AssayType.DBA_DtoH: 'DtoH'}
+
+
+@dataclass
+class SimSpec:
+    """Everything needed to simulate, assembled from the live controls."""
+
+    assay_type: AssayType
+    assay_cls: Type[BaseAssay]
+    conditions: dict[str, Any]  # Quantity-valued (+ 'mode' str for DBA)
+    parameters: dict[str, float]  # base-unit floats keyed by parameter_keys
+    conc_mode: str
+    conc_kwargs: dict[str, Any]
+    noise: dict[str, Any]
+
+
+class SimulationPanel(QWidget):
+    """Live control stack: model/condition knobs + titration vector + noise."""
+
+    changed = pyqtSignal()
+
+    def __init__(self, assay_type: AssayType = AssayType.IDA, parent=None):
+        super().__init__(parent)
+        self._assay_type = assay_type
+        self._controls: dict[str, ParameterControl] = {}
+        self._is_condition: dict[str, bool] = {}
+
+        root = QVBoxLayout(self)
+        root.setContentsMargins(0, 0, 0, 0)
+        root.setSpacing(8)
+
+        self._knob_box = QGroupBox('Model parameters & conditions')
+        self._knob_layout = QVBoxLayout(self._knob_box)
+        self._knob_layout.setSpacing(2)
+        root.addWidget(self._knob_box)
+
+        conc_box = QGroupBox('Titration')
+        conc_layout = QVBoxLayout(conc_box)
+        self._conc_label = QLabel()
+        conc_layout.addWidget(self._conc_label)
+        self._conc_input = ConcentrationInput()
+        conc_layout.addWidget(self._conc_input)
+        root.addWidget(conc_box)
+
+        noise_box = QGroupBox('Noise')
+        noise_layout = QVBoxLayout(noise_box)
+        self._noise = NoiseControl()
+        noise_layout.addWidget(self._noise)
+        root.addWidget(noise_box)
+
+        self._conc_input.changed.connect(self.changed)
+        self._noise.changed.connect(self.changed)
+
+        self.set_assay_type(assay_type, _reset_range=True)
+
+    # -- public API ----------------------------------------------------------
+
+    def assay_type(self) -> AssayType:
+        return self._assay_type
+
+    def set_assay_type(self, assay_type: AssayType, *, _reset_range: bool = True) -> None:
+        """Rebuild the knob controls for *assay_type* (registry-driven)."""
+        self._assay_type = assay_type
+        self._rebuild_knobs(assay_type)
+        species = ASSAY_REGISTRY[assay_type].x_label
+        self._conc_label.setTextFormat(Qt.TextFormat.RichText)
+        self._conc_label.setText(f'Titrated species: <b>{species}</b>')
+        if _reset_range:
+            start, stop = TITRANT_RANGE.get(assay_type, (0.0, 50e-6))
+            self._conc_input.set_linear(start, stop, _DEFAULT_N)
+        self.changed.emit()
+
+    def set_concentration_explicit(self, values_m) -> None:
+        """Switch the titration input to an explicit vector (Molar). Used on data import."""
+        self._conc_input.load_spec('explicit', {'values': [float(v) for v in values_m]})
+
+    def spec(self) -> SimSpec:
+        conditions: dict[str, Any] = {}
+        parameters: dict[str, float] = {}
+        for key, ctrl in self._controls.items():
+            if self._is_condition.get(key, False):
+                conditions[key] = ctrl.quantity()
+            else:
+                parameters[key] = ctrl.value()
+        if self._assay_type in _DBA_MODE:
+            conditions['mode'] = _DBA_MODE[self._assay_type]
+        conc_mode, conc_kwargs = self._conc_input.spec()
+        return SimSpec(
+            assay_type=self._assay_type,
+            assay_cls=assay_class(self._assay_type),
+            conditions=conditions,
+            parameters=parameters,
+            conc_mode=conc_mode,
+            conc_kwargs=conc_kwargs,
+            noise=self._noise.settings(),
+        )
+
+    def state(self) -> dict:
+        """Full serializable settings for save."""
+        mode, kwargs = self._conc_input.spec()
+        return {
+            'assay_type': self._assay_type.name,
+            'knobs': {key: ctrl.state() for key, ctrl in self._controls.items()},
+            'concentration': {'mode': mode, 'kwargs': kwargs},
+            'noise': self._noise.settings(),
+        }
+
+    def load_state(self, data: dict) -> None:
+        at = AssayType[data['assay_type']]
+        self.set_assay_type(at, _reset_range=False)
+        for key, st in data.get('knobs', {}).items():
+            if key in self._controls:
+                self._controls[key].load_state(st)
+        conc = data.get('concentration', {})
+        if conc:
+            self._conc_input.load_spec(conc.get('mode', 'linear'), conc.get('kwargs', {}))
+        self._noise.load_settings(data.get('noise', {}))
+        self.changed.emit()
+
+    # -- internals -----------------------------------------------------------
+
+    def _rebuild_knobs(self, assay_type: AssayType) -> None:
+        while self._knob_layout.count():
+            item = self._knob_layout.takeAt(0)
+            w = item.widget()
+            if w is not None:
+                w.deleteLater()
+        self._controls.clear()
+        self._is_condition.clear()
+        for knob in knobs_for(assay_type):
+            ctrl = ParameterControl(knob)
+            ctrl.changed.connect(self.changed)
+            self._knob_layout.addWidget(ctrl)
+            self._controls[knob.key] = ctrl
+            self._is_condition[knob.key] = knob.is_condition

--- a/gui/simulation/simulation_window.py
+++ b/gui/simulation/simulation_window.py
@@ -1,0 +1,246 @@
+"""SimulationWindow — the non-modal forward-simulation applet.
+
+Left: a two-level assay selector + the registry-driven control stack.  Right: a
+live :class:`PlotWidget`.  Every control change re-evaluates the forward model at
+the user's concentration vector and redraws — no fitting.  The window is opened
+non-modally so the main fitting window stays usable alongside it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+from PyQt6.QtGui import QAction
+from PyQt6.QtWidgets import (
+    QFileDialog,
+    QMainWindow,
+    QMessageBox,
+    QScrollArea,
+    QSplitter,
+    QStatusBar,
+    QToolBar,
+    QVBoxLayout,
+    QWidget,
+)
+
+from core.assays.registry import ASSAY_REGISTRY, AssayType
+from core.simulation import build_concentration_vector, simulate_dataset, simulate_signal
+from gui.plotting.plot_widget import PlotWidget
+from gui.simulation.settings_io import load_simulation_settings, save_simulation_settings
+from gui.simulation.simulation_panel import SimulationPanel
+from gui.widgets.assay_type_selector import AssayTypeSelector
+
+_INITIAL_ASSAY = AssayType.IDA
+
+
+class SimulationWindow(QMainWindow):
+    """Interactive forward-simulation applet (non-modal)."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle('Simulate Titration — SupraSimFit')
+        self.resize(1100, 720)
+
+        # (concentrations_M, [(replica_id, signal), ...]) of imported data to overlay.
+        self._imported: tuple[np.ndarray, list[tuple[str, np.ndarray]]] | None = None
+
+        self._build_toolbar()
+
+        splitter = QSplitter()
+        splitter.setChildrenCollapsible(False)
+        self.setCentralWidget(splitter)
+
+        # Left: selector + control stack, scrollable.
+        left = QWidget()
+        left_layout = QVBoxLayout(left)
+        left_layout.setContentsMargins(8, 8, 8, 8)
+        self._selector = AssayTypeSelector(initial=_INITIAL_ASSAY)
+        self._panel = SimulationPanel(assay_type=_INITIAL_ASSAY)
+        left_layout.addWidget(self._selector)
+        left_layout.addWidget(self._panel)
+        left_layout.addStretch()
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setWidget(left)
+        scroll.setMinimumWidth(360)
+        splitter.addWidget(scroll)
+
+        self._plot = PlotWidget()
+        splitter.addWidget(self._plot)
+        splitter.setStretchFactor(0, 0)
+        splitter.setStretchFactor(1, 1)
+
+        self.setStatusBar(QStatusBar())
+
+        self._selector.assay_type_changed.connect(self._on_assay_changed)
+        self._panel.changed.connect(self._recompute)
+
+        self._recompute()
+
+    # -- toolbar -------------------------------------------------------------
+
+    def _build_toolbar(self) -> None:
+        tb = QToolBar('Simulation')
+        tb.setMovable(False)
+        self.addToolBar(tb)
+        for text, slot, tip in (
+            ('Export Curve…', self._on_export_curve, 'Save the plotted curve as PNG or SVG'),
+            ('Export Data…', self._on_export_data, 'Save the simulated points as a loadable TXT/CSV'),
+            ('Save Settings…', self._on_save_settings, 'Save all parameters/bounds/noise to JSON'),
+            ('Load Settings…', self._on_load_settings, 'Restore parameters/bounds/noise from JSON'),
+            ('Import Data…', self._on_import_data, 'Overlay a measurement file on the simulated curve'),
+        ):
+            act = QAction(text, self)
+            act.setToolTip(tip)
+            act.triggered.connect(slot)
+            tb.addAction(act)
+
+    # -- slots ---------------------------------------------------------------
+
+    def _on_assay_changed(self, assay_type: AssayType) -> None:
+        self._imported = None  # imported overlay no longer applies to a different assay
+        self._panel.set_assay_type(assay_type)  # emits changed → _recompute
+
+    def _recompute(self) -> None:
+        """Re-evaluate the forward model and redraw.  Errors surface in the status bar."""
+        try:
+            spec = self._panel.spec()
+            x = build_concentration_vector(spec.conc_mode, **spec.conc_kwargs)
+            y = simulate_signal(spec.assay_cls, spec.conditions, spec.parameters, x)
+        except Exception as exc:  # invalid range / non-physical params / solver failure
+            self.statusBar().showMessage(f'⚠ {exc}')
+            return
+
+        scatter: list[tuple[str, np.ndarray]] = []
+        noise = spec.noise
+        if noise['enabled'] and noise['frac'] > 0:
+            ms = simulate_dataset(
+                spec.assay_cls,
+                spec.conditions,
+                spec.parameters,
+                x,
+                noise_frac=noise['frac'],
+                n_replicas=noise['replicas'],
+                rng=np.random.default_rng(noise['seed']),
+            )
+            scatter.extend(zip(ms.replica_ids, list(ms.signals)))
+
+        if self._imported is not None:
+            xi, reps = self._imported
+            if len(xi) == len(x):
+                scatter.extend(reps)
+            else:
+                self.statusBar().showMessage('Imported overlay hidden — concentration grid changed.')
+
+        meta = ASSAY_REGISTRY[spec.assay_type]
+        plot_data = {
+            'concentrations': x,
+            'active_replicas': scatter,
+            'dropped_replicas': [],
+            'average': None,
+            'fits': [{'x': x, 'y': y, 'label': 'Simulated model', 'id': 'sim'}],
+        }
+        self._plot.update_plot(plot_data, x_label=meta.x_label, y_label=meta.y_label, y_unit=meta.y_unit)
+        self.statusBar().showMessage(f'{meta.display_name} — {len(x)} points')
+
+    def _on_export_curve(self) -> None:
+        path, _ = QFileDialog.getSaveFileName(
+            self, 'Export Curve', self._default_name('.png'), 'PNG image (*.png);;SVG vector (*.svg)'
+        )
+        if not path:
+            return
+        try:
+            self._plot.export_image(path)
+            self.statusBar().showMessage(f'Curve saved to {path}')
+        except Exception as exc:
+            QMessageBox.warning(self, 'Export Error', str(exc))
+
+    def _on_export_data(self) -> None:
+        try:
+            spec = self._panel.spec()
+            x = build_concentration_vector(spec.conc_mode, **spec.conc_kwargs)
+        except Exception as exc:
+            QMessageBox.warning(self, 'Cannot Export', str(exc))
+            return
+        path, _ = QFileDialog.getSaveFileName(
+            self, 'Export Simulated Data', self._default_name('.txt'), 'Text file (*.txt);;CSV file (*.csv)'
+        )
+        if not path:
+            return
+        noise = spec.noise
+        replicas = noise['replicas'] if noise['enabled'] else 1
+        ms = simulate_dataset(
+            spec.assay_cls,
+            spec.conditions,
+            spec.parameters,
+            x,
+            noise_frac=noise['frac'] if noise['enabled'] else 0.0,
+            n_replicas=replicas,
+            rng=np.random.default_rng(noise['seed']),
+        )
+        try:
+            if Path(path).suffix.lower() == '.csv':
+                from core.io.formats.measurement_writer import write_measurements_csv
+
+                write_measurements_csv(ms, path)
+            else:
+                from core.io.formats.measurement_writer import write_measurements_txt
+
+                if Path(path).suffix.lower() != '.txt':
+                    path = str(Path(path).with_suffix('.txt'))
+                write_measurements_txt(ms, path)
+        except Exception as exc:
+            QMessageBox.warning(self, 'Export Error', str(exc))
+            return
+        self.statusBar().showMessage(f'Simulated data exported to {path}')
+
+    def _on_save_settings(self) -> None:
+        path, _ = QFileDialog.getSaveFileName(self, 'Save Settings', self._default_name('.json'), 'JSON (*.json)')
+        if not path:
+            return
+        try:
+            save_simulation_settings(self._panel.state(), path)
+            self.statusBar().showMessage(f'Settings saved to {path}')
+        except Exception as exc:
+            QMessageBox.warning(self, 'Save Error', str(exc))
+
+    def _on_load_settings(self) -> None:
+        path, _ = QFileDialog.getOpenFileName(self, 'Load Settings', '', 'JSON (*.json);;All files (*)')
+        if not path:
+            return
+        try:
+            state = load_simulation_settings(path)
+            self._selector.set_assay_type(AssayType[state['assay_type']])
+            self._panel.load_state(state)
+            self.statusBar().showMessage(f'Settings loaded from {path}')
+        except Exception as exc:
+            QMessageBox.warning(self, 'Load Error', str(exc))
+
+    def _on_import_data(self) -> None:
+        path, _ = QFileDialog.getOpenFileName(
+            self, 'Import Measurement Data', '', 'Data files (*.txt *.csv *.xlsx);;All files (*)'
+        )
+        if not path:
+            return
+        try:
+            from core.data_processing.measurement_set import MeasurementSet
+            from core.io import load_measurements
+
+            ms = MeasurementSet.from_dataframe(load_measurements(path))
+        except Exception as exc:
+            QMessageBox.warning(self, 'Import Error', f'Could not load data:\n{exc}')
+            return
+        self._imported = (
+            np.asarray(ms.concentrations, dtype=float),
+            [(f'data:{rid}', np.asarray(sig, dtype=float)) for rid, sig in zip(ms.replica_ids, ms.signals)],
+        )
+        # Evaluate the model at the imported grid so the comparison lines up.
+        self._panel.set_concentration_explicit(ms.concentrations)
+        self.statusBar().showMessage(f'Imported {ms.n_replicas} replica(s) from {Path(path).name}')
+
+    # -- helpers -------------------------------------------------------------
+
+    def _default_name(self, suffix: str) -> str:
+        return f'simulation_{self._panel.assay_type().name}{suffix}'

--- a/gui/widgets/assay_type_selector.py
+++ b/gui/widgets/assay_type_selector.py
@@ -1,0 +1,97 @@
+"""AssayTypeSelector — a standalone two-level (category → subtype) assay picker.
+
+Derived from ``ASSAY_REGISTRY`` (grouped by ``AssayMetadata.category``), it emits
+``assay_type_changed`` exactly once per selection.  Used by the simulation applet;
+``AssayConfigPanel`` keeps its own equivalent selector (only two call sites, so no
+shared abstraction is forced).
+"""
+
+from __future__ import annotations
+
+from PyQt6.QtCore import pyqtSignal
+from PyQt6.QtWidgets import QComboBox, QVBoxLayout, QWidget
+
+from core.assays.registry import ASSAY_REGISTRY, AssayType
+
+
+class AssayTypeSelector(QWidget):
+    """Two dependent combos: assay *category* then *subtype*.
+
+    Signals
+    -------
+    assay_type_changed(AssayType)
+        Emitted once whenever the selected assay type changes.
+    """
+
+    assay_type_changed = pyqtSignal(object)  # AssayType
+
+    def __init__(self, initial: AssayType = AssayType.IDA, parent=None):
+        super().__init__(parent)
+        self._current_type = initial
+        self._groups: dict[str, list[AssayType]] = {}
+        for at, meta in ASSAY_REGISTRY.items():
+            self._groups.setdefault(meta.category, []).append(at)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        self._main_combo = QComboBox()
+        for category in self._groups:
+            self._main_combo.addItem(category, userData=category)
+        layout.addWidget(self._main_combo)
+
+        self._sub_combo = QComboBox()
+        layout.addWidget(self._sub_combo)
+
+        # Initial selection without emitting during construction.
+        category = ASSAY_REGISTRY[initial].category
+        self._main_combo.blockSignals(True)
+        self._main_combo.setCurrentIndex(self._main_combo.findData(category))
+        self._main_combo.blockSignals(False)
+        self._populate_sub(category)
+        self._sub_combo.setCurrentIndex(self._sub_combo.findData(initial))
+
+        self._main_combo.currentIndexChanged.connect(self._on_main_changed)
+        self._sub_combo.currentIndexChanged.connect(self._on_sub_changed)
+
+    # -- public API ----------------------------------------------------------
+
+    def current_assay_type(self) -> AssayType:
+        return self._current_type
+
+    def set_assay_type(self, assay_type: AssayType) -> None:
+        """Programmatically select an assay, emitting ``assay_type_changed`` once."""
+        category = ASSAY_REGISTRY[assay_type].category
+        main_blocked = self._main_combo.blockSignals(True)
+        sub_blocked = self._sub_combo.blockSignals(True)
+        self._main_combo.setCurrentIndex(self._main_combo.findData(category))
+        self._populate_sub(category)
+        self._sub_combo.setCurrentIndex(self._sub_combo.findData(assay_type))
+        self._main_combo.blockSignals(main_blocked)
+        self._sub_combo.blockSignals(sub_blocked)
+        self._apply(assay_type)
+
+    # -- internals -----------------------------------------------------------
+
+    def _populate_sub(self, category: str) -> None:
+        was_blocked = self._sub_combo.blockSignals(True)
+        self._sub_combo.clear()
+        for at in self._groups[category]:
+            self._sub_combo.addItem(ASSAY_REGISTRY[at].subtype_label, userData=at)
+        self._sub_combo.setCurrentIndex(0)
+        self._sub_combo.blockSignals(was_blocked)
+
+    def _apply(self, assay_type: AssayType) -> None:
+        self._current_type = assay_type
+        self.assay_type_changed.emit(assay_type)
+
+    def _on_main_changed(self, idx: int) -> None:
+        category = self._main_combo.itemData(idx)
+        self._populate_sub(category)
+        self._apply(self._sub_combo.itemData(0))
+
+    def _on_sub_changed(self, idx: int) -> None:
+        at = self._sub_combo.itemData(idx)
+        if at is None:  # transient empty state during repopulation
+            return
+        self._apply(at)

--- a/tests/integration/test_simulation_recovery.py
+++ b/tests/integration/test_simulation_recovery.py
@@ -1,0 +1,60 @@
+"""End-to-end: data simulated by the applet's core is recoverable by the fitter.
+
+This is the round-trip that justifies "no divergent math" — generate a titration
+with a known Ka via :func:`core.simulation.simulate_dataset`, fit it back with the
+real pipeline, and confirm Ka returns within the clean-data tolerance.  Slow (runs
+a multi-start fit), so kept to two representative assays.
+"""
+
+from core.assays.gda import GDAAssay
+from core.assays.ida import IDAAssay
+from core.pipeline.fit_pipeline import FitConfig, fit_measurement_set
+from core.simulation import build_concentration_vector, simulate_dataset
+from core.units import Q_
+from tests.conftest import (
+    GDA_IDA_RECOVERY_BOUNDS,
+    GDA_TRUE,
+    IDA_TRUE,
+    assert_within_tolerance,
+)
+
+_CLEAN_TOL = 0.10
+_N_TRIALS = 100  # matches N_TRIALS_CLEAN in test_pipeline_e2e for clean-data recovery
+
+
+def _params(true: dict) -> dict:
+    return {k: true[k] for k in ('Ka_guest', 'I0', 'I_dye_free', 'I_dye_bound')}
+
+
+def test_simulated_gda_recovers_ka():
+    conditions = {
+        'Ka_dye': Q_(GDA_TRUE['Ka_dye'], '1/M'),
+        'h0': Q_(GDA_TRUE['h0'], 'M'),
+        'g0': Q_(GDA_TRUE['g0'], 'M'),
+    }
+    x = build_concentration_vector('linear', start=1e-7, stop=30e-6, n=30)
+    ms = simulate_dataset(GDAAssay, conditions, _params(GDA_TRUE), x)  # clean
+
+    result = fit_measurement_set(
+        ms, GDAAssay, conditions, FitConfig(n_trials=_N_TRIALS, custom_bounds=GDA_IDA_RECOVERY_BOUNDS)
+    )
+
+    assert result.success
+    assert_within_tolerance(result.parameters['Ka_guest'], GDA_TRUE['Ka_guest'], _CLEAN_TOL, 'Ka_guest')
+
+
+def test_simulated_ida_recovers_ka():
+    conditions = {
+        'Ka_dye': Q_(IDA_TRUE['Ka_dye'], '1/M'),
+        'h0': Q_(IDA_TRUE['h0'], 'M'),
+        'd0': Q_(IDA_TRUE['d0'], 'M'),
+    }
+    x = build_concentration_vector('linear', start=0.0, stop=50e-6, n=30)
+    ms = simulate_dataset(IDAAssay, conditions, _params(IDA_TRUE), x)  # clean
+
+    result = fit_measurement_set(
+        ms, IDAAssay, conditions, FitConfig(n_trials=_N_TRIALS, custom_bounds=GDA_IDA_RECOVERY_BOUNDS)
+    )
+
+    assert result.success
+    assert_within_tolerance(result.parameters['Ka_guest'], IDA_TRUE['Ka_guest'], _CLEAN_TOL, 'Ka_guest')

--- a/tests/unit/gui/test_simulation_applet.py
+++ b/tests/unit/gui/test_simulation_applet.py
@@ -13,10 +13,16 @@ import pytest
 
 from core.assays.registry import ASSAY_REGISTRY, AssayType
 from core.simulation import build_concentration_vector, simulate_signal
-from gui.simulation.controls import ConcentrationInput, ParameterControl
-from gui.simulation.sim_knob import SimKnob, knobs_for
+from core.units import Q_
+from gui.simulation.controls import ConcentrationInput, ParameterControl, _display_factor
+from gui.simulation.sim_knob import knobs_for
 from gui.simulation.simulation_panel import SimulationPanel
 from gui.widgets.assay_conditions import condition_fields
+
+
+def _knob(assay_type, key):
+    """Fetch a real registry-sourced knob (carries its canonical Pint unit)."""
+    return next(k for k in knobs_for(assay_type) if k.key == key)
 
 
 def test_knob_set_is_registry_union_without_mode(qapp):
@@ -41,29 +47,44 @@ def test_dba_treats_ka_dye_as_parameter(qapp):
 
 
 def test_log_slider_maps_geometrically(qapp):
-    knob = SimKnob('Ka', 'Ka', '', 'binding', 'M⁻¹', 1e6, 1e3, 1e9, is_condition=False)
+    knob = _knob(AssayType.GDA, 'Ka_guest')  # association constant → log slider, [1e3, 1e9]
     c = ParameterControl(knob)
     c._slider.setValue(0)
-    assert c.value() == pytest.approx(1e3, rel=1e-3)
+    assert c.value() == pytest.approx(knob.vmin, rel=1e-3)
     c._slider.setValue(1000)
-    assert c.value() == pytest.approx(1e9, rel=1e-3)
+    assert c.value() == pytest.approx(knob.vmax, rel=1e-3)
     c._slider.setValue(500)  # midpoint of a log slider is the geometric mean
-    assert c.value() == pytest.approx(math.sqrt(1e3 * 1e9), rel=1e-2)
+    assert c.value() == pytest.approx(math.sqrt(knob.vmin * knob.vmax), rel=1e-2)
 
 
 def test_linear_slider_maps_arithmetically(qapp):
-    knob = SimKnob('I', 'I', '', 'signal', 'au/M', 5e7, 0.0, 1e8, is_condition=False)
+    knob = _knob(AssayType.GDA, 'I_dye_free')  # signal coefficient → linear slider
     c = ParameterControl(knob)
     c._slider.setValue(500)
-    assert c.value() == pytest.approx(5e7, rel=1e-2)
+    assert c.value() == pytest.approx((knob.vmin + knob.vmax) / 2, rel=1e-2)
 
 
 def test_signal_coefficient_allows_negative(qapp):
     """A calibration intercept must be settable below zero (registry widget cannot)."""
-    knob = next(k for k in knobs_for(AssayType.DYE_ALONE) if k.key == 'intercept')
+    knob = _knob(AssayType.DYE_ALONE, 'intercept')
     c = ParameterControl(knob)
     c.load_state({'value': -250.0, 'min': -1e4, 'max': 1e4})
     assert c.value() == pytest.approx(-250.0)
+
+
+def test_concentration_unit_switch_preserves_physical_quantity(qapp):
+    """Switching a concentration knob's display unit must not change the physical value."""
+    c = ParameterControl(_knob(AssayType.GDA, 'h0'))  # concentration → has a nM/µM/mM/M selector
+    base = c.quantity().to('M').magnitude
+    for unit in ('nM', 'mM', 'M', 'µM'):
+        c._unit_combo.setCurrentText(unit)
+        assert c.quantity().to('M').magnitude == pytest.approx(base, rel=1e-9)
+
+
+def test_display_factor_is_pint_derived(qapp):
+    """Concentration scale factors come from Pint (core.units), not hardcoded literals."""
+    assert _display_factor('nM', 'M') == Q_(1, 'nM').to('M').magnitude
+    assert _display_factor('mM', 'M') == Q_(1, 'mM').to('M').magnitude
 
 
 def test_concentration_log_mode_round_trips_to_geometric_vector(qapp):

--- a/tests/unit/gui/test_simulation_applet.py
+++ b/tests/unit/gui/test_simulation_applet.py
@@ -1,0 +1,115 @@
+"""GUI tests for the forward-simulation applet.
+
+These pin the applet-specific contracts (not the forward-model math, which
+``tests/unit/test_simulation.py`` covers): the registry-driven knob set, the
+slider↔value mapping, negative-coefficient support, settings persistence, and
+that every assay's default state yields a usable curve.
+"""
+
+import math
+
+import numpy as np
+import pytest
+
+from core.assays.registry import ASSAY_REGISTRY, AssayType
+from core.simulation import build_concentration_vector, simulate_signal
+from gui.simulation.controls import ConcentrationInput, ParameterControl
+from gui.simulation.sim_knob import SimKnob, knobs_for
+from gui.simulation.simulation_panel import SimulationPanel
+from gui.widgets.assay_conditions import condition_fields
+
+
+def test_knob_set_is_registry_union_without_mode(qapp):
+    """Each assay's knobs are exactly its conditions ∪ parameters — and never ``mode``."""
+    panel = SimulationPanel()
+    for at in AssayType:
+        panel.set_assay_type(at)
+        keys = set(panel._controls)
+        expected = {f.key for f in condition_fields(at)} | set(ASSAY_REGISTRY[at].parameter_keys)
+        assert keys == expected, at
+        assert 'mode' not in keys  # categorical — derived from subtype, not a knob
+
+
+def test_dba_treats_ka_dye_as_parameter(qapp):
+    """Regression for the assay-uniformity bug: Ka_dye is a *parameter* in DBA."""
+    panel = SimulationPanel()
+    panel.set_assay_type(AssayType.DBA_DtoH)
+    spec = panel.spec()
+    assert 'Ka_dye' in spec.parameters  # not a condition here
+    assert 'Ka_dye' not in spec.conditions
+    assert spec.conditions['mode'] == 'DtoH'
+
+
+def test_log_slider_maps_geometrically(qapp):
+    knob = SimKnob('Ka', 'Ka', '', 'binding', 'M⁻¹', 1e6, 1e3, 1e9, is_condition=False)
+    c = ParameterControl(knob)
+    c._slider.setValue(0)
+    assert c.value() == pytest.approx(1e3, rel=1e-3)
+    c._slider.setValue(1000)
+    assert c.value() == pytest.approx(1e9, rel=1e-3)
+    c._slider.setValue(500)  # midpoint of a log slider is the geometric mean
+    assert c.value() == pytest.approx(math.sqrt(1e3 * 1e9), rel=1e-2)
+
+
+def test_linear_slider_maps_arithmetically(qapp):
+    knob = SimKnob('I', 'I', '', 'signal', 'au/M', 5e7, 0.0, 1e8, is_condition=False)
+    c = ParameterControl(knob)
+    c._slider.setValue(500)
+    assert c.value() == pytest.approx(5e7, rel=1e-2)
+
+
+def test_signal_coefficient_allows_negative(qapp):
+    """A calibration intercept must be settable below zero (registry widget cannot)."""
+    knob = next(k for k in knobs_for(AssayType.DYE_ALONE) if k.key == 'intercept')
+    c = ParameterControl(knob)
+    c.load_state({'value': -250.0, 'min': -1e4, 'max': 1e4})
+    assert c.value() == pytest.approx(-250.0)
+
+
+def test_concentration_log_mode_round_trips_to_geometric_vector(qapp):
+    ci = ConcentrationInput()
+    ci.load_spec('log', {'start': 1e-8, 'stop': 1e-4, 'n': 9})
+    mode, kwargs = ci.spec()
+    v = build_concentration_vector(mode, **kwargs)
+    ratios = v[1:] / v[:-1]
+    assert np.allclose(ratios, ratios[0], rtol=1e-4)
+
+
+def test_settings_round_trip_restores_assay_and_values(qapp):
+    panel = SimulationPanel()
+    panel.set_assay_type(AssayType.GDA)
+    panel._controls['Ka_guest'].load_state({'value': 3e6, 'min': 1e3, 'max': 1e9})
+    saved = panel.state()
+
+    panel.set_assay_type(AssayType.DYE_ALONE)  # perturb
+    panel.load_state(saved)
+    restored = panel.state()
+
+    assert restored['assay_type'] == 'GDA'
+    assert restored['knobs']['Ka_guest']['value'] == pytest.approx(3e6)
+
+
+def test_every_assay_default_yields_a_non_flat_curve(qapp):
+    """Each assay opens on a simulatable, visibly-shaped curve (first-open UX)."""
+    panel = SimulationPanel()
+    for at in AssayType:
+        panel.set_assay_type(at)
+        spec = panel.spec()
+        x = build_concentration_vector(spec.conc_mode, **spec.conc_kwargs)
+        y = simulate_signal(spec.assay_cls, spec.conditions, spec.parameters, x)
+        assert y.shape == x.shape
+        assert np.ptp(y) > 0, f'{at.name} default curve is flat'
+
+
+def test_window_recompute_overlays_noisy_scatter(qapp):
+    """Enabling noise puts N replicate scatter series alongside the model line."""
+    from gui.simulation.simulation_window import SimulationWindow
+
+    w = SimulationWindow()
+    captured: dict = {}
+    w._plot.update_plot = lambda pd, **kw: captured.update(pd)  # intercept the redraw
+    w._panel._noise.load_settings({'enabled': True, 'frac': 0.05, 'replicas': 3, 'seed': 1})
+    w._recompute()
+
+    assert len(captured['active_replicas']) == 3
+    assert captured['fits'][0]['label'] == 'Simulated model'

--- a/tests/unit/test_simulation.py
+++ b/tests/unit/test_simulation.py
@@ -1,0 +1,254 @@
+"""Tests for the forward-simulation core (``core.simulation``).
+
+Scientific contract: a simulation must reproduce the *exact* forward-model math the
+fitter uses (no divergent re-implementation), for every assay type — including the
+linear DYE_ALONE assay whose ``forward_model`` has a different signature.
+"""
+
+import numpy as np
+import pytest
+
+from core.assays import DBAAssay, DyeAloneAssay, GDAAssay, H2GAssay, HG2Assay, IDAAssay
+from core.models.equilibrium import dba_signal, gda_signal, h2g_signal, hg2_signal, ida_signal
+from core.models.linear import linear_signal
+from core.simulation import build_concentration_vector, simulate_dataset, simulate_signal
+from core.units import Q_
+from tests.conftest import DBA_TRUE, DYE_ALONE_TRUE, GDA_TRUE, H2G_TRUE, HG2_TRUE, IDA_TRUE
+
+# ---------------------------------------------------------------------------
+# Each case: (assay_cls, conditions (Quantities), parameters, x_vector, expected y)
+# `expected` is computed from the canonical model function directly, so equality
+# proves the simulation reuses the same math.
+# ---------------------------------------------------------------------------
+
+
+def _gda_case():
+    x = np.linspace(1e-7, 30e-6, 25)
+    t = GDA_TRUE
+    expected = gda_signal(
+        I0=t['I0'],
+        Ka_guest=t['Ka_guest'],
+        I_dye_free=t['I_dye_free'],
+        I_dye_bound=t['I_dye_bound'],
+        Ka_dye=t['Ka_dye'],
+        h0=t['h0'],
+        d0_values=x,
+        g0=t['g0'],
+    )
+    conditions = {'Ka_dye': Q_(t['Ka_dye'], '1/M'), 'h0': Q_(t['h0'], 'M'), 'g0': Q_(t['g0'], 'M')}
+    params = {'Ka_guest': t['Ka_guest'], 'I0': t['I0'], 'I_dye_free': t['I_dye_free'], 'I_dye_bound': t['I_dye_bound']}
+    return GDAAssay, conditions, params, x, expected
+
+
+def _ida_case():
+    x = np.linspace(0, 50e-6, 25)
+    t = IDA_TRUE
+    expected = ida_signal(
+        I0=t['I0'],
+        Ka_guest=t['Ka_guest'],
+        I_dye_free=t['I_dye_free'],
+        I_dye_bound=t['I_dye_bound'],
+        Ka_dye=t['Ka_dye'],
+        h0=t['h0'],
+        d0=t['d0'],
+        g0_values=x,
+    )
+    conditions = {'Ka_dye': Q_(t['Ka_dye'], '1/M'), 'h0': Q_(t['h0'], 'M'), 'd0': Q_(t['d0'], 'M')}
+    params = {'Ka_guest': t['Ka_guest'], 'I0': t['I0'], 'I_dye_free': t['I_dye_free'], 'I_dye_bound': t['I_dye_bound']}
+    return IDAAssay, conditions, params, x, expected
+
+
+def _dba_case(mode):
+    x = np.linspace(1e-7, 50e-6, 25)
+    t = DBA_TRUE
+    expected = dba_signal(
+        I0=t['I0'],
+        Ka_dye=t['Ka_dye'],
+        I_dye_free=t['I_dye_free'],
+        I_dye_bound=t['I_dye_bound'],
+        x_titrant=x,
+        y_fixed=t['fixed_conc'],
+        mode=mode,
+    )
+    conditions = {'fixed_conc': Q_(t['fixed_conc'], 'M'), 'mode': mode}
+    params = {'Ka_dye': t['Ka_dye'], 'I0': t['I0'], 'I_dye_free': t['I_dye_free'], 'I_dye_bound': t['I_dye_bound']}
+    return DBAAssay, conditions, params, x, expected
+
+
+def _hg2_case():
+    x = np.linspace(0, 1.2e-3, 25)
+    t = HG2_TRUE
+    expected = hg2_signal(
+        I0=t['I0'],
+        Ka_HG=t['Ka_HG'],
+        Ka_HG2=t['Ka_HG2'],
+        I_G=t['I_G'],
+        I_H=t['I_H'],
+        I_HG=t['I_HG'],
+        I_HG2=t['I_HG2'],
+        h0=t['h0'],
+        g0_values=x,
+    )
+    conditions = {'h0': Q_(t['h0'], 'M')}
+    params = {k: t[k] for k in ('Ka_HG', 'Ka_HG2', 'I0', 'I_G', 'I_H', 'I_HG', 'I_HG2')}
+    return HG2Assay, conditions, params, x, expected
+
+
+def _h2g_case():
+    x = np.linspace(0, 6e-4, 25)
+    t = H2G_TRUE
+    expected = h2g_signal(
+        I0=t['I0'],
+        Ka_HG=t['Ka_HG'],
+        Ka_H2G=t['Ka_H2G'],
+        I_G=t['I_G'],
+        I_H=t['I_H'],
+        I_HG=t['I_HG'],
+        I_H2G=t['I_H2G'],
+        h0=t['h0'],
+        g0_values=x,
+    )
+    conditions = {'h0': Q_(t['h0'], 'M')}
+    params = {k: t[k] for k in ('Ka_HG', 'Ka_H2G', 'I0', 'I_G', 'I_H', 'I_HG', 'I_H2G')}
+    return H2GAssay, conditions, params, x, expected
+
+
+def _dye_alone_case():
+    x = np.linspace(0, 20e-6, 25)
+    t = DYE_ALONE_TRUE
+    expected = linear_signal(t['slope'], t['intercept'], x)
+    return DyeAloneAssay, {}, {'slope': t['slope'], 'intercept': t['intercept']}, x, expected
+
+
+ALL_CASES = {
+    'GDA': _gda_case(),
+    'IDA': _ida_case(),
+    'DBA_DtoH': _dba_case('DtoH'),
+    'DBA_HtoD': _dba_case('HtoD'),
+    'HG2': _hg2_case(),
+    'H2G': _h2g_case(),
+    'DYE_ALONE': _dye_alone_case(),
+}
+
+
+@pytest.mark.parametrize('name', list(ALL_CASES))
+def test_simulate_signal_matches_forward_model(name):
+    """simulate_signal reproduces the canonical model math exactly, for every assay."""
+    assay_cls, conditions, params, x, expected = ALL_CASES[name]
+    got = simulate_signal(assay_cls, conditions, params, x)
+    assert got.shape == x.shape
+    np.testing.assert_allclose(got, np.asarray(expected, dtype=float), rtol=1e-9, atol=0)
+
+
+def test_dye_alone_is_exact_line():
+    """DYE_ALONE (no-`x` forward_model) is the closed-form slope*x + intercept."""
+    x = np.linspace(0, 1e-4, 11)
+    got = simulate_signal(DyeAloneAssay, {}, {'slope': 5e10, 'intercept': 100.0}, x)
+    np.testing.assert_allclose(got, 5e10 * x + 100.0, rtol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# build_concentration_vector
+# ---------------------------------------------------------------------------
+
+
+def test_linear_mode_is_uniformly_spaced():
+    v = build_concentration_vector('linear', start=0.0, stop=1e-4, n=11)
+    assert (v[0], v[-1], len(v)) == (0.0, 1e-4, 11)
+    diffs = np.diff(v)
+    assert np.allclose(diffs, diffs[0])  # uniform spacing
+
+
+def test_step_mode_has_constant_step():
+    v = build_concentration_vector('step', start=1e-6, step=2e-6, n=5)
+    assert v[0] == 1e-6 and len(v) == 5
+    assert np.allclose(np.diff(v), 2e-6)
+
+
+def test_log_mode_is_geometrically_spaced():
+    v = build_concentration_vector('log', start=1e-8, stop=1e-4, n=9)
+    assert (v[0], v[-1], len(v)) == (1e-8, 1e-4, 9)
+    ratios = v[1:] / v[:-1]
+    assert np.allclose(ratios, ratios[0])  # constant ratio = geometric
+
+
+def test_explicit_mode_preserves_values():
+    v = build_concentration_vector('explicit', values=[0.0, 3e-6, 1e-5])
+    np.testing.assert_array_equal(v, [0.0, 3e-6, 1e-5])
+
+
+@pytest.mark.parametrize(
+    'mode,kwargs',
+    [
+        ('linear', dict(start=-1e-6, stop=1e-5, n=5)),  # negative start
+        ('step', dict(start=-2e-6, step=1e-6, n=2)),  # produces negatives
+        ('explicit', dict(values=[1e-6, -2e-6])),  # explicit negative
+    ],
+)
+def test_rejects_negative_concentrations(mode, kwargs):
+    with pytest.raises(ValueError, match='negative'):
+        build_concentration_vector(mode, **kwargs)
+
+
+@pytest.mark.parametrize(
+    'mode,kwargs',
+    [
+        ('linear', dict(start=1e-5, stop=1e-5, n=5)),  # stop == start
+        ('linear', dict(start=0.0, stop=1e-4, n=1)),  # n < 2
+        ('step', dict(start=0.0, step=0.0, n=5)),  # non-positive step
+        ('log', dict(start=0.0, stop=1e-4, n=5)),  # log start <= 0
+        ('explicit', dict(values=[])),  # empty
+        ('bogus', dict()),  # unknown mode
+    ],
+)
+def test_invalid_specs_raise(mode, kwargs):
+    with pytest.raises(ValueError):
+        build_concentration_vector(mode, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# simulate_dataset
+# ---------------------------------------------------------------------------
+
+
+def test_dataset_shapes_and_clean():
+    assay_cls, conditions, params, x, expected = ALL_CASES['IDA']
+    ms = simulate_dataset(assay_cls, conditions, params, x, n_replicas=3)
+    assert ms.signals.shape == (3, x.size)
+    assert ms.concentrations.shape == x.shape
+    # No noise → every replica equals the clean signal.
+    for row in ms.signals:
+        np.testing.assert_allclose(row, np.asarray(expected, dtype=float), rtol=1e-9)
+
+
+def test_noise_is_seed_reproducible_and_scaled():
+    assay_cls, conditions, params, x, expected = ALL_CASES['IDA']
+    a = simulate_dataset(assay_cls, conditions, params, x, noise_frac=0.05, n_replicas=4, rng=np.random.default_rng(7))
+    b = simulate_dataset(assay_cls, conditions, params, x, noise_frac=0.05, n_replicas=4, rng=np.random.default_rng(7))
+    np.testing.assert_array_equal(a.signals, b.signals)
+    # Different seed → different draw.
+    c = simulate_dataset(assay_cls, conditions, params, x, noise_frac=0.05, n_replicas=4, rng=np.random.default_rng(8))
+    assert not np.array_equal(a.signals, c.signals)
+    # Residual scatter scales roughly with noise_frac * signal span.
+    clean = np.asarray(expected, dtype=float)
+    span = clean.max() - clean.min()
+    resid_sd = np.std(a.signals - clean)
+    assert 0.2 * 0.05 * span < resid_sd < 5 * 0.05 * span
+
+
+def test_dataset_roundtrips_through_writer(tmp_path):
+    """Exported simulated data re-loads to a MeasurementSet of the same shape/values."""
+    from core.data_processing.measurement_set import MeasurementSet
+    from core.io import load_measurements
+    from core.io.formats.measurement_writer import write_measurements_txt
+
+    assay_cls, conditions, params, x, _ = ALL_CASES['GDA']
+    ms = simulate_dataset(assay_cls, conditions, params, x, n_replicas=2)
+    path = tmp_path / 'sim.txt'
+    write_measurements_txt(ms, path)
+
+    df = load_measurements(str(path))
+    reloaded = MeasurementSet.from_dataframe(df)
+    assert reloaded.signals.shape == ms.signals.shape
+    np.testing.assert_allclose(reloaded.concentrations, ms.concentrations, rtol=1e-5)
+    np.testing.assert_allclose(np.sort(reloaded.signals, axis=0), np.sort(ms.signals, axis=0), rtol=1e-5)


### PR DESCRIPTION
## Why
Before running a real experiment, users want to predict a titration curve from chosen parameters — to choose sensible concentration ranges, point counts, and tolerable noise — without needing measured data first. The app could only *fit* measured data; this adds the inverse.

Closes #32.

## What changed
- **`core/simulation.py`** — a pure forward-simulation core that **reuses the existing assay forward models** (no divergent math): builds a titrant vector (explicit / linear / start-step / log, rejecting negative concentrations), evaluates `forward_model` uniformly for all 7 assays, and optionally adds Gaussian noise (a fraction of the signal range) → a `MeasurementSet`.
- **`gui/simulation/`** — a non-modal **Simulate…** applet (toolbar + File menu). A registry-driven control stack renders every assay with no bespoke UI: each condition/parameter is a live slider with user-settable bounds (log for association constants), plus flexible concentration input and a noise control. The curve updates live via the existing `PlotWidget`. Export the curve (PNG/SVG), the simulated data (loadable/fittable TXT/CSV), or the full settings (JSON); import a measurement file to overlay for comparison.
- **`gui/widgets/assay_type_selector.py`** — a small standalone two-level assay picker for the applet.

## How to verify
```
uv run pytest tests/unit/test_simulation.py tests/unit/gui/test_simulation_applet.py tests/integration/test_simulation_recovery.py
```
- The integration test simulates GDA/IDA from a known Ka and **recovers it through the real fitter** (simulate ↔ fit round-trip), which is the concrete "no divergent math" guarantee.
- In the app (`uv run run_app.py`): toolbar **Simulate…** → pick an assay → drag a slider and watch the curve update live; switch the concentration mode (e.g. log-spaced); enable noise; **Export Data** → **Import Data** into a fitting session → **Run Fit** to recover the chosen parameters. The main fitting window stays usable alongside the applet.

## Notes / flags
- A simulation is drawn via the **curve-only** plot path, not a fabricated `FitResult`, so no fake R²/uncertainties leak into the summary/distribution widgets.
- **Plan deviation:** the two-level selector is a new standalone widget rather than an extraction that also refactors `AssayConfigPanel`. A selector shared by only two call sites doesn't warrant a forced abstraction, and this keeps `AssayConfigPanel` and its tests untouched.
- Noise is a fraction of the signal range (scale-invariant across assays whose magnitudes differ by orders of magnitude), matching the `conftest` idiom. A screenshot of the applet (IDA, model curve + 3 noisy replicas) was shared during development.
