### PR TITLE
feat: batch-import multiple files as replicas in one session

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,7 @@ Tests verify **scientific correctness first** — reproduce a bug as a failing t
 ## GUI Conventions
 
 - **No silent fallbacks:** any unmet precondition must show `QMessageBox.warning()` with an explanation and fix instructions. Never silently skip or default. App behaviour must always reflect the user's configuration exactly.
+- **User-facing messages are for users, not developers:** every error, warning, and dialog must be plain language a non-technical user understands — stating what happened, why, and what to do next, and naming the specific inputs involved (e.g. offending files/values) when it helps. Keep them as short and precise as the situation allows — no lengthiness. Never surface raw exception text, tracebacks, or library/debug phrasing (e.g. a numpy broadcast error); catch low-level errors at the boundary and translate them.
 - **Unit-aware inputs:** `_UnitWidget` in `assay_config_panel.py` always returns base-unit floats (M or M⁻¹) regardless of display unit.
 - **Locale:** `QLocale.setDefault(English/US)` in `launch()` before `QApplication` — guarantees dot decimal separators in all spinboxes.
 - **HTML labels:** `ConditionField.label` is HTML; render with `lbl.setTextFormat(Qt.TextFormat.RichText)`. Use subscript/superscript consistently.

--- a/core/io/__init__.py
+++ b/core/io/__init__.py
@@ -65,9 +65,10 @@ def load_measurements_multi(paths: Sequence[str | Path]) -> pd.DataFrame:
     Each file is read with :func:`load_measurements` and contributes its
     replica(s) to a combined long-format frame. Replica labels are made
     globally unique from the file stem, so the source of each replicate stays
-    visible downstream. The combined frame is ready for
-    :meth:`MeasurementSet.from_dataframe`, which enforces the shared
-    concentration grid across replicas (a genuine mismatch raises there).
+    visible downstream. Files must share one concentration grid: a differing
+    number of titration points is rejected here with a plain-language,
+    file-named message, and any remaining value mismatch is caught by
+    :meth:`MeasurementSet.from_dataframe`.
 
     Parameters
     ----------
@@ -86,14 +87,16 @@ def load_measurements_multi(paths: Sequence[str | Path]) -> pd.DataFrame:
     Raises
     ------
     ValueError
-        If *paths* is empty, or a file carries a ``channel`` column or
-        placeholder concentrations.
+        If *paths* is empty; a file carries a ``channel`` column or placeholder
+        concentrations; or the files do not all have the same number of
+        titration points.
     """
     if not paths:
         raise ValueError('No files provided')
 
     frames: list[pd.DataFrame] = []
     stem_counts: dict[str, int] = {}
+    point_counts: list[tuple[str, int]] = []
     for raw in paths:
         path = Path(raw)
         df = load_measurements(path)
@@ -108,6 +111,7 @@ def load_measurements_multi(paths: Sequence[str | Path]) -> pd.DataFrame:
                 'column); batch replica import expects files that carry their own '
                 'concentrations. Import it individually and enter concentrations.'
             )
+        point_counts.append((path.name, len(df) // max(int(df['replica'].nunique()), 1)))
 
         # Provenance-carrying, globally unique replica label per file.
         seen = stem_counts.get(path.stem, 0)
@@ -121,6 +125,19 @@ def load_measurements_multi(paths: Sequence[str | Path]) -> pd.DataFrame:
         else:
             out['replica'] = label
         frames.append(out)
+
+    # Replicate files must describe the same titration — i.e. share one
+    # concentration grid. Catch a differing number of titration points here,
+    # with a plain-language, file-named message, rather than letting the raw
+    # array-shape mismatch surface from downstream numpy code.
+    if len({n for _, n in point_counts}) > 1:
+        listing = '\n'.join(f'• {name} — {n} points' for name, n in point_counts)
+        raise ValueError(
+            'These files have different numbers of titration points, so they '
+            f'cannot be loaded as replicates of one measurement:\n\n{listing}\n\n'
+            'Replicates must share the same titration points. Select files from '
+            'the same measurement, or files with matching point counts.'
+        )
 
     return pd.concat(frames, ignore_index=True)
 

--- a/core/io/__init__.py
+++ b/core/io/__init__.py
@@ -6,12 +6,17 @@ load_measurements(path) -> pd.DataFrame
     Load measurement data from file. Returns long-format DataFrame
     with columns: concentration, signal, replica.
 
+load_measurements_multi(paths) -> pd.DataFrame
+    Load several files and stack them as replicas in one long-format
+    DataFrame (replica labels derived from file stems).
+
 save_results(results, path) -> None
     Save fit results dict to file.
 
 Supported formats: .txt (tab-separated, multi-replica)
 """
 
+from collections.abc import Sequence
 from pathlib import Path
 
 import pandas as pd
@@ -28,6 +33,8 @@ from core.io.formats import csv_reader  # noqa: F401
 from core.io.formats import xlsx_reader  # noqa: F401
 
 # isort: on
+from core.io.formats.bmg_reader import BMG_PLACEHOLDER_KEY
+from core.io.formats.ensight_reader import ENSIGHT_CHANNEL_COLUMN
 from core.io.registry import get_reader, get_writer
 
 
@@ -52,6 +59,72 @@ def load_measurements(path: str | Path) -> pd.DataFrame:
     return reader.read(path)
 
 
+def load_measurements_multi(paths: Sequence[str | Path]) -> pd.DataFrame:
+    """Load several measurement files and stack them as replicas.
+
+    Each file is read with :func:`load_measurements` and contributes its
+    replica(s) to a combined long-format frame. Replica labels are made
+    globally unique from the file stem, so the source of each replicate stays
+    visible downstream. The combined frame is ready for
+    :meth:`MeasurementSet.from_dataframe`, which enforces the shared
+    concentration grid across replicas (a genuine mismatch raises there).
+
+    Parameters
+    ----------
+    paths : sequence of str or Path
+        Files to load. Each must be a single-curve file carrying its own
+        concentrations; a file with multiple channels (e.g. an EnSight export)
+        or placeholder concentrations (e.g. a plate export) is rejected —
+        import those one at a time.
+
+    Returns
+    -------
+    pd.DataFrame
+        Long-format frame with columns ``concentration``, ``signal`` and
+        ``replica`` (string labels derived from the file stems).
+
+    Raises
+    ------
+    ValueError
+        If *paths* is empty, or a file carries a ``channel`` column or
+        placeholder concentrations.
+    """
+    if not paths:
+        raise ValueError('No files provided')
+
+    frames: list[pd.DataFrame] = []
+    stem_counts: dict[str, int] = {}
+    for raw in paths:
+        path = Path(raw)
+        df = load_measurements(path)
+        if ENSIGHT_CHANNEL_COLUMN in df.columns:
+            raise ValueError(
+                f"'{path.name}' carries multiple channels; batch import handles "
+                'single-curve files only. Import multi-channel files individually.'
+            )
+        if df.attrs.get(BMG_PLACEHOLDER_KEY):
+            raise ValueError(
+                f"'{path.name}' has placeholder concentrations (no real concentration "
+                'column); batch replica import expects files that carry their own '
+                'concentrations. Import it individually and enter concentrations.'
+            )
+
+        # Provenance-carrying, globally unique replica label per file.
+        seen = stem_counts.get(path.stem, 0)
+        stem_counts[path.stem] = seen + 1
+        label = path.stem if seen == 0 else f'{path.stem} ({seen + 1})'
+
+        out = df[['concentration', 'signal']].copy()
+        replicas = df['replica']
+        if replicas.nunique() > 1:
+            out['replica'] = label + '#' + replicas.astype(str)
+        else:
+            out['replica'] = label
+        frames.append(out)
+
+    return pd.concat(frames, ignore_index=True)
+
+
 def save_results(results: dict, path: str | Path) -> None:
     """Save fit results to file.
 
@@ -67,4 +140,4 @@ def save_results(results: dict, path: str | Path) -> None:
     writer.write(results, path)
 
 
-__all__ = ['load_measurements', 'save_results']
+__all__ = ['load_measurements', 'load_measurements_multi', 'save_results']

--- a/gui/widgets/data_panel.py
+++ b/gui/widgets/data_panel.py
@@ -26,7 +26,7 @@ from core.data_processing.concentration import (
     save_concentration_vector,
 )
 from core.data_processing.measurement_set import MeasurementSet
-from core.io import load_measurements
+from core.io import load_measurements, load_measurements_multi
 from core.io.formats.bmg_reader import BMG_METADATA_KEY, BMG_PLACEHOLDER_KEY
 from core.io.formats.ensight_reader import (
     ENSIGHT_CHANNEL_COLUMN,
@@ -64,6 +64,11 @@ what you load here.</p>
 or <b>Demo IDA</b> for a bundled example. The format is detected from the
 file. Supported: {ext_list} &mdash; including JASCO and PerkinElmer EnSight
 CSVs and BMG plate exports.</p>
+
+<p><b>Multiple replicates:</b> select several files in the import dialog to load
+them as replicas in one session (e.g. repeated JASCO titrations). They must
+share the same concentration grid; a file whose grid differs is rejected with
+an explanation.</p>
 
 <p><b>Your own data &mdash; quickest path:</b> a plain CSV with a header row,
 concentration in the first column and signal in the second:</p>
@@ -131,6 +136,7 @@ class DataPanel(InfoGroupBox):
         )
         self._ms: MeasurementSet | None = None
         self._source_path: str | None = None
+        self._source_paths: list[str] = []
         self._face_values: np.ndarray = np.array([], dtype=np.float64)
         self._imported_unit: str = DEFAULT_IMPORTED_UNIT
         self._suppress_cell_signal: bool = False
@@ -226,18 +232,31 @@ class DataPanel(InfoGroupBox):
     # ------------------------------------------------------------------
 
     def load_file(self, path: str | None = None) -> None:
-        """Load a measurement file, optionally bypassing the dialog.
+        """Load one or more measurement files.
 
-        The import path is identical for every format: parse → build the
-        MeasurementSet → emit. No modal dialog runs mid-load. When the
-        parsed frame carries multiple channels, the full frame is kept in
-        memory and the first channel is shown; the Channel combo lets the
-        user switch without re-reading the file.
+        From the dialog the user may select several files; each is stacked as a
+        replica in a single MeasurementSet (they must share one concentration
+        grid). A single file — or a programmatic ``path`` — keeps the original
+        per-format behaviour, including multi-channel handling.
         """
-        if path is None:
-            path, _ = QFileDialog.getOpenFileName(self, 'Load Measurement File', '', _build_file_filter())
-        if not path:
+        if path is not None:
+            self._load_single(path)
             return
+        paths, _ = QFileDialog.getOpenFileNames(self, 'Import Data', '', _build_file_filter())
+        if not paths:
+            return
+        if len(paths) == 1:
+            self._load_single(paths[0])
+        else:
+            self._load_multiple(paths)
+
+    def _load_single(self, path: str) -> None:
+        """Load a single file: parse → build the MeasurementSet → emit.
+
+        No modal dialog runs mid-load. When the parsed frame carries multiple
+        channels, the full frame is kept in memory and the first channel is
+        shown; the Channel combo lets the user switch without re-reading.
+        """
         try:
             df = load_measurements(path)
         except Exception as exc:
@@ -258,12 +277,43 @@ class DataPanel(InfoGroupBox):
         self._channels = channels
         self._ms = ms
         self._source_path = path
+        self._source_paths = [path]
         # Numbers in the file are taken as face values (no implicit unit
         # conversion). Default the Imported Unit to M, which matches the
         # historical loader behavior and preserves fits on existing files.
         self._face_values = np.asarray(ms.concentrations, dtype=np.float64).copy()
         self._imported_unit = DEFAULT_IMPORTED_UNIT
         self._populate_channel_combo(df)
+        self._refresh_after_load()
+        self.data_loaded.emit(ms)
+
+    def _load_multiple(self, paths: list[str]) -> None:
+        """Stack several files as replicas in one MeasurementSet.
+
+        Replica labels come from the file stems (provenance). All files must
+        share one concentration grid — a genuine mismatch is rejected by
+        ``MeasurementSet.from_dataframe`` and surfaced as a warning. Batch
+        import is single-curve only; multi-channel files are refused upstream.
+        """
+        try:
+            combined = load_measurements_multi(paths)
+            ms = MeasurementSet.from_dataframe(
+                combined,
+                source_file=str(paths[0]),
+                source_files=[str(p) for p in paths],
+            )
+        except Exception as exc:
+            QMessageBox.warning(self, 'Load Error', f'Could not load files:\n{exc}')
+            return
+
+        self._multi_channel_df = None
+        self._channels = []
+        self._ms = ms
+        self._source_path = str(paths[0])
+        self._source_paths = [str(p) for p in paths]
+        self._face_values = np.asarray(ms.concentrations, dtype=np.float64).copy()
+        self._imported_unit = DEFAULT_IMPORTED_UNIT
+        self._populate_channel_combo(combined)
         self._refresh_after_load()
         self.data_loaded.emit(ms)
 
@@ -353,6 +403,7 @@ class DataPanel(InfoGroupBox):
     def clear(self) -> None:
         self._ms = None
         self._source_path = None
+        self._source_paths = []
         self._face_values = np.array([], dtype=np.float64)
         self._multi_channel_df = None
         self._channels = []
@@ -529,8 +580,13 @@ class DataPanel(InfoGroupBox):
     def _update_info(self) -> None:
         if self._ms is None:
             return
-        name = Path(self._source_path).name if self._source_path else '?'
-        self._file_label.setText(name)
+        if len(self._source_paths) > 1:
+            names = [Path(p).name for p in self._source_paths]
+            self._file_label.setText(f'{len(names)} files → {self._ms.n_replicas} replicas')
+            self._file_label.setToolTip('\n'.join(names))
+        else:
+            self._file_label.setText(Path(self._source_path).name if self._source_path else '?')
+            self._file_label.setToolTip('')
         self._info_label.setText(f'{self._ms.n_points} points × {self._ms.n_replicas} replicas')
 
     def _set_concentration_controls_enabled(self, enabled: bool) -> None:

--- a/gui/widgets/data_panel.py
+++ b/gui/widgets/data_panel.py
@@ -303,7 +303,7 @@ class DataPanel(InfoGroupBox):
                 source_files=[str(p) for p in paths],
             )
         except Exception as exc:
-            QMessageBox.warning(self, 'Load Error', f'Could not load files:\n{exc}')
+            QMessageBox.warning(self, 'Load Error', str(exc))
             return
 
         self._multi_channel_df = None

--- a/tests/unit/gui/test_data_panel.py
+++ b/tests/unit/gui/test_data_panel.py
@@ -222,3 +222,52 @@ class TestJascoLoadIntegration:
         assert 'jasco_metadata' in ms.metadata
         sections = ms.metadata['jasco_metadata']['sections']
         assert sections['Measurement Information']['Ex wavelength'] == '415.0 nm'
+
+
+class TestMultiFileReplicaLoad:
+    """Selecting several files in the import dialog stacks them as replicas."""
+
+    def test_multi_select_loads_files_as_replicas(self, qapp, tmp_path, monkeypatch):
+        if not JASCO_FIXTURE.exists():
+            pytest.skip('JASCO fixture missing')
+        from gui.widgets import data_panel
+        from gui.widgets.data_panel import DataPanel
+
+        # Three copies of the same titration → three replicas sharing one grid.
+        text = JASCO_FIXTURE.read_text()
+        paths = []
+        for stem in ('rep_a', 'rep_b', 'rep_c'):
+            p = tmp_path / f'{stem}.csv'
+            p.write_text(text)
+            paths.append(str(p))
+        monkeypatch.setattr(data_panel.QFileDialog, 'getOpenFileNames', lambda *a, **k: (paths, ''))
+
+        panel = DataPanel()
+        emissions = []
+        panel.data_loaded.connect(lambda ms: emissions.append(ms))
+        panel.load_file()  # no path → dialog (monkeypatched to return 3 files)
+
+        ms = panel.measurement_set()
+        assert ms is not None
+        assert len(emissions) == 1
+        assert ms.n_replicas == 3
+        assert set(ms.replica_ids) == {'rep_a', 'rep_b', 'rep_c'}
+        assert len(ms.metadata.get('source_files', [])) == 3
+        # DataPanel shows the multi-file summary rather than a single filename.
+        assert '3 files' in panel._file_label.text()
+
+    def test_single_select_still_one_replica(self, qapp, tmp_path, monkeypatch):
+        if not JASCO_FIXTURE.exists():
+            pytest.skip('JASCO fixture missing')
+        from gui.widgets import data_panel
+        from gui.widgets.data_panel import DataPanel
+
+        p = tmp_path / 'solo.csv'
+        p.write_text(JASCO_FIXTURE.read_text())
+        monkeypatch.setattr(data_panel.QFileDialog, 'getOpenFileNames', lambda *a, **k: ([str(p)], ''))
+
+        panel = DataPanel()
+        panel.load_file()  # one file selected → original single-file path
+        ms = panel.measurement_set()
+        assert ms.n_replicas == 1
+        assert panel._file_label.text() == 'solo.csv'

--- a/tests/unit/test_io_multi.py
+++ b/tests/unit/test_io_multi.py
@@ -1,0 +1,107 @@
+"""Tests for batch-loading several files as replicas (``load_measurements_multi``).
+
+Covers the data-integrity round-trip (N files → N replica rows, each preserved),
+the fail-fast contract on a genuine concentration-grid mismatch, provenance
+labelling (replica IDs from file stems, duplicates disambiguated), and the
+refusal of multi-channel files. See issue #35.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import core.io as io
+from core.data_processing.measurement_set import MeasurementSet
+from core.io import load_measurements_multi
+from core.io.formats.bmg_reader import BMG_PLACEHOLDER_KEY
+
+
+def _jasco(concs_umol: list[float], signals: list[float]) -> str:
+    """Minimal JASCO-shaped CSV: concentrations in µmol/L, given signals."""
+    rows = '\n'.join(f'{c:.4f},{s:.4f}' for c, s in zip(concs_umol, signals))
+    return (
+        'TITLE,t\n'
+        'DATA TYPE,FLUORESCENCE SPECTRUM\n'
+        'ORIGIN,JASCO\n'
+        'XUNITS,Concentration [umol/L]\n'
+        'YUNITS,INTENSITY\n'
+        f'NPOINTS,{len(concs_umol)}\n'
+        'XYDATA\n' + rows + '\n'
+    )
+
+
+def _write(path, concs_umol: list[float], signals: list[float]) -> str:
+    path.write_text(_jasco(concs_umol, signals))
+    return str(path)
+
+
+def test_three_files_stack_as_replicas(tmp_path):
+    """Three same-grid JASCO files load as three replicas, each round-tripped."""
+    concs = [0.0, 1.0, 2.0]  # µmol/L → 0, 1e-6, 2e-6 M
+    files = {
+        'repA': [10.0, 20.0, 30.0],
+        'repB': [11.0, 21.0, 31.0],
+        'repC': [12.0, 22.0, 32.0],
+    }
+    paths = [_write(tmp_path / f'{stem}.csv', concs, sig) for stem, sig in files.items()]
+
+    ms = MeasurementSet.from_dataframe(load_measurements_multi(paths))
+
+    assert ms.n_replicas == 3
+    assert set(ms.replica_ids) == set(files)
+    np.testing.assert_allclose(ms.concentrations, [0.0, 1e-6, 2e-6])
+    # Each replica row preserves its own file's signals (data integrity).
+    for stem, sig in files.items():
+        np.testing.assert_allclose(ms.get_replica_signal(stem), sig)
+
+
+def test_mismatched_grid_rejected(tmp_path):
+    """Files with different concentration grids must fail fast at build time."""
+    a = _write(tmp_path / 'a.csv', [0.0, 1.0, 2.0], [1.0, 2.0, 3.0])
+    b = _write(tmp_path / 'b.csv', [0.0, 1.0, 3.0], [1.0, 2.0, 3.0])  # last point differs
+    combined = load_measurements_multi([a, b])
+    with pytest.raises(ValueError, match='different concentration grid'):
+        MeasurementSet.from_dataframe(combined)
+
+
+def test_duplicate_stems_disambiguated(tmp_path):
+    """Same file name in different folders → distinct replica IDs, no collision."""
+    (tmp_path / 'one').mkdir()
+    (tmp_path / 'two').mkdir()
+    p1 = _write(tmp_path / 'one' / 'rep.csv', [0.0, 1.0], [1.0, 2.0])
+    p2 = _write(tmp_path / 'two' / 'rep.csv', [0.0, 1.0], [3.0, 4.0])
+
+    ms = MeasurementSet.from_dataframe(load_measurements_multi([p1, p2]))
+    assert ms.n_replicas == 2
+    assert set(ms.replica_ids) == {'rep', 'rep (2)'}
+
+
+def test_empty_paths_raises():
+    with pytest.raises(ValueError, match='No files'):
+        load_measurements_multi([])
+
+
+def test_channel_file_rejected(tmp_path, monkeypatch):
+    """A file that parses to a multi-channel frame is refused (single-curve only)."""
+    channel_df = pd.DataFrame(
+        {
+            'concentration': [0.0, 1e-6],
+            'signal': [1.0, 2.0],
+            'replica': [0, 0],
+            'channel': ['A', 'A'],
+        }
+    )
+    monkeypatch.setattr(io, 'load_measurements', lambda _p: channel_df)
+    with pytest.raises(ValueError, match='channel'):
+        load_measurements_multi([tmp_path / 'x.csv'])
+
+
+def test_placeholder_concentration_file_rejected(tmp_path, monkeypatch):
+    """A file with placeholder concentrations is refused — never fit silently."""
+    placeholder_df = pd.DataFrame({'concentration': [1.0, 2.0], 'signal': [1.0, 2.0], 'replica': [0, 0]})
+    placeholder_df.attrs[BMG_PLACEHOLDER_KEY] = True
+    monkeypatch.setattr(io, 'load_measurements', lambda _p: placeholder_df)
+    with pytest.raises(ValueError, match='placeholder concentrations'):
+        load_measurements_multi([tmp_path / 'plate.xlsx'])

--- a/tests/unit/test_io_multi.py
+++ b/tests/unit/test_io_multi.py
@@ -66,6 +66,20 @@ def test_mismatched_grid_rejected(tmp_path):
         MeasurementSet.from_dataframe(combined)
 
 
+def test_mismatched_point_counts_rejected(tmp_path):
+    """Different numbers of titration points are rejected with a plain-language,
+    file-named message — not a raw numpy broadcast error (issue: batch import)."""
+    a = _write(tmp_path / 'run_a.csv', [0.0, 1.0, 2.0], [10.0, 20.0, 30.0])  # 3 points
+    b = _write(tmp_path / 'run_b.csv', [0.0, 1.0, 2.0, 3.0], [10.0, 20.0, 30.0, 40.0])  # 4 points
+    with pytest.raises(ValueError) as excinfo:
+        load_measurements_multi([a, b])
+    msg = str(excinfo.value)
+    assert 'titration points' in msg
+    assert 'run_a.csv' in msg and 'run_b.csv' in msg
+    assert '3' in msg and '4' in msg
+    assert 'broadcast' not in msg  # the cryptic numpy error must not leak through
+
+
 def test_duplicate_stems_disambiguated(tmp_path):
     """Same file name in different folders → distinct replica IDs, no collision."""
     (tmp_path / 'one').mkdir()


### PR DESCRIPTION
## Why

Jasco titration import only accepted a single file per session — i.e. a single replica. Researchers running replicate titrations on the instrument had to import them one at a time. Closes #35.

## What changed

- The **Import Data…** dialog (Ctrl+O) is now multi-select. Selecting several files stacks them as replicas in one session; selecting one file behaves exactly as before.
- New Qt-free helper `load_measurements_multi(paths)` in `core/io/` reads each file via the existing `load_measurements`, labels each file's replica by its file **stem** (provenance; duplicate names disambiguated), and concatenates into one long-format frame for `MeasurementSet.from_dataframe`.
- The shared concentration grid is enforced by the existing `from_dataframe` check — a genuine mismatch is **rejected with a clear warning, never silently interpolated**. Multi-channel (EnSight) and placeholder-concentration (plate) files are refused in batch mode (import those individually).
- DataPanel shows "N files → N replicas" (file names in the tooltip); replicas are labelled by source file in the ReplicaPanel and plot.

Format-agnostic — any single-curve files sharing a grid can be stacked, though batch Jasco replicates are the motivating case. No fitting-pipeline changes.

## How to verify

```bash
uv run pytest tests/unit/test_io_multi.py tests/unit/gui/test_data_panel.py
```

Manually: `uv run run_app.py` → **Import Data…** → multi-select a few `.csv` titrations sharing a grid (e.g. copies of `tests/data/jasco/cb7in30umbc_1-1.csv`) → DataPanel shows "3 files → 3 replicas", the ReplicaPanel lists each file, the plot shows three curves, and a fit runs. Re-import a single file to confirm unchanged behaviour. Selecting files with different grids pops a clear warning instead of crashing.

## Notes / flags

- `source_file` and the tab title use the first selected file as a representative; the full list is kept in `MeasurementSet.metadata['source_files']`.
- Per-file instrument metadata (`jasco_metadata`) is not aggregated for batch loads (it isn't used downstream); single-file import still forwards it as before.
