### PR TITLE
Redesign ensemble analysis: report a real fit, keep valid fits

### DIFF
--- a/core/data_processing/plotting.py
+++ b/core/data_processing/plotting.py
@@ -65,7 +65,7 @@ def prepare_plot_data(
     fits: list[Dict[str, Any]] = []
     if fit_results:
         for fr in fit_results:
-            label = 'Median Fit'
+            label = 'Best Fit'
             x = fr.x_fit.magnitude
             y = fr.y_fit.magnitude
             fits.append(

--- a/core/optimizer/__init__.py
+++ b/core/optimizer/__init__.py
@@ -1,13 +1,20 @@
 """Optimization utilities for fitting binding assay models."""
 
+from core.optimizer.ensemble import (
+    DEFAULT_STATISTICS_MODE,
+    ENSEMBLE_STATISTICS,
+    EnsembleResult,
+    EnsembleStatistic,
+    central_spread,
+    collapse,
+    select_representative_index,
+    summarize,
+)
 from core.optimizer.filters import (
-    aggregate_fits,
     calculate_fit_metrics,
-    compute_mad,
-    compute_median_params,
     filter_by_r_squared,
     filter_by_rmse,
-    filter_fits,
+    select_valid_fits,
 )
 from core.optimizer.linear_fit import linear_regression
 from core.optimizer.multistart import FitAttempt, generate_initial_guesses, multistart_minimize
@@ -20,11 +27,17 @@ __all__ = [
     # filters.py
     'filter_by_rmse',
     'filter_by_r_squared',
-    'filter_fits',
-    'compute_median_params',
-    'compute_mad',
-    'aggregate_fits',
+    'select_valid_fits',
     'calculate_fit_metrics',
+    # ensemble.py
+    'ENSEMBLE_STATISTICS',
+    'DEFAULT_STATISTICS_MODE',
+    'EnsembleStatistic',
+    'EnsembleResult',
+    'collapse',
+    'select_representative_index',
+    'central_spread',
+    'summarize',
     # linear_fit.py
     'linear_regression',
 ]

--- a/core/optimizer/ensemble.py
+++ b/core/optimizer/ensemble.py
@@ -122,15 +122,21 @@ def select_representative_index(quality: dict[str, np.ndarray]) -> int:
     Parameters
     ----------
     quality : dict[str, np.ndarray]
-        Must contain ``'r_squared'`` (and conventionally ``'rmse'``),
-        one value per valid trial.
+        Must contain ``'r_squared'`` and ``'rmse'``, one value per valid
+        trial (RMSE breaks R² ties).
 
     Returns
     -------
     int
         Index of the representative trial.
     """
-    return int(np.argmax(quality['r_squared']))
+    # Highest R², ties broken by lowest RMSE. On a fixed dataset R² and RMSE
+    # are monotone (argmax R² == argmin RMSE); the tiebreak only matters when
+    # R² collapses (e.g. constant y → ss_tot == 0 → every R² == 0), where RMSE
+    # still identifies the genuinely best fit.
+    r2 = np.asarray(quality['r_squared'], dtype=float)
+    rmse = np.asarray(quality['rmse'], dtype=float)
+    return int(np.lexsort((rmse, -r2))[0])
 
 
 def collapse(

--- a/core/optimizer/ensemble.py
+++ b/core/optimizer/ensemble.py
@@ -1,0 +1,204 @@
+"""Ensemble collapse: turn a pool of valid fits into one reported result.
+
+This module is the **single source of operation** for collapsing the
+multi-start (or per-replica) pool of valid fits into the values the app
+reports. It does three things, each in one place:
+
+1. **Select the representative** — :func:`select_representative_index`
+   picks the single real fit that drives the plotted curve and the
+   reported value/RMSE/R² (default: highest R², which is identical to
+   lowest RMSE on a fixed dataset).
+2. **Collapse the pool** — :func:`collapse` bundles the per-parameter
+   sample pool, the per-trial quality pool, and the representative index
+   into an :class:`EnsembleResult`.
+3. **Summarise the spread** — the :data:`ENSEMBLE_STATISTICS` registry
+   defines each aggregation mode (central tendency + dispersion) once;
+   :func:`central_spread` and :func:`summarize` read from it.
+
+The module is pure ``numpy`` — it operates on arrays, not assays, so both
+pipeline paths and the GUI reuse it. To experiment with a new aggregation
+add one entry to :data:`ENSEMBLE_STATISTICS`; to change which fit is
+reported edit :func:`select_representative_index`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Primitive per-parameter statistics — defined once, reused everywhere.
+# ---------------------------------------------------------------------------
+
+
+def _median(samples: np.ndarray) -> float:
+    return float(np.median(samples))
+
+
+def _mad(samples: np.ndarray) -> float:
+    """Median absolute deviation — robust dispersion around the median."""
+    med = np.median(samples)
+    return float(np.median(np.abs(samples - med)))
+
+
+def _mean(samples: np.ndarray) -> float:
+    return float(np.mean(samples))
+
+
+def _std(samples: np.ndarray) -> float:
+    """Sample standard deviation; 0 for a single sample (no spread defined)."""
+    return float(np.std(samples, ddof=1)) if samples.size > 1 else 0.0
+
+
+@dataclass(frozen=True)
+class EnsembleStatistic:
+    """One named way to summarise a 1-D pool of per-parameter samples.
+
+    Attributes
+    ----------
+    label : str
+        Human-readable label (e.g. ``'Median ± MAD'``) — drives the GUI
+        toggle option text.
+    central : Callable[[np.ndarray], float]
+        Central-tendency estimator (e.g. median or mean).
+    spread : Callable[[np.ndarray], float]
+        Dispersion estimator (e.g. MAD or standard deviation).
+    """
+
+    label: str
+    central: Callable[[np.ndarray], float]
+    spread: Callable[[np.ndarray], float]
+
+
+#: The extension point — add a key here to offer a new aggregation mode
+#: across the pipeline, the table, the annotation, and the export.
+ENSEMBLE_STATISTICS: dict[str, EnsembleStatistic] = {
+    'median': EnsembleStatistic('Median ± MAD', _median, _mad),
+    'mean': EnsembleStatistic('Mean ± STDEV', _mean, _std),
+}
+
+#: Default reported aggregation (robust).
+DEFAULT_STATISTICS_MODE = 'median'
+
+
+@dataclass
+class EnsembleResult:
+    """Mode-independent structural collapse of a valid-fit pool.
+
+    Attributes
+    ----------
+    representative_index : int
+        Index (into every ``parameter_samples`` / ``quality_samples``
+        array) of the representative fit — the real fit that drives the
+        curve and the reported value/RMSE/R².
+    parameter_samples : dict[str, np.ndarray]
+        One flat array per parameter key holding every valid trial's
+        value, aligned by index.
+    quality_samples : dict[str, np.ndarray]
+        ``{'rmse': ..., 'r_squared': ...}`` — per-trial fit quality,
+        aligned to ``parameter_samples`` by index.
+    """
+
+    representative_index: int
+    parameter_samples: dict[str, np.ndarray]
+    quality_samples: dict[str, np.ndarray]
+
+    @property
+    def representative_params(self) -> np.ndarray:
+        """Representative parameter vector, ordered as ``parameter_samples``."""
+        i = self.representative_index
+        return np.array([arr[i] for arr in self.parameter_samples.values()], dtype=float)
+
+
+def select_representative_index(quality: dict[str, np.ndarray]) -> int:
+    """Index of the representative fit — the one place this criterion lives.
+
+    Selects the highest R², which is identical to the lowest RMSE on a
+    fixed dataset (``R² = 1 − SS_res/SS_tot``, ``RMSE = √(SS_res/n)`` are
+    both monotone in ``SS_res``). R² is the more intuitive label.
+
+    Parameters
+    ----------
+    quality : dict[str, np.ndarray]
+        Must contain ``'r_squared'`` (and conventionally ``'rmse'``),
+        one value per valid trial.
+
+    Returns
+    -------
+    int
+        Index of the representative trial.
+    """
+    return int(np.argmax(quality['r_squared']))
+
+
+def collapse(
+    param_matrix: np.ndarray,
+    rmse: np.ndarray,
+    r_squared: np.ndarray,
+    parameter_keys: list[str],
+) -> EnsembleResult:
+    """Bundle a valid-fit pool into an :class:`EnsembleResult`.
+
+    Parameters
+    ----------
+    param_matrix : np.ndarray
+        ``(n_valid, n_params)`` array of valid-trial parameter vectors.
+    rmse, r_squared : np.ndarray
+        ``(n_valid,)`` per-trial quality, aligned to ``param_matrix`` rows.
+    parameter_keys : list[str]
+        Parameter names, ordered to match ``param_matrix`` columns.
+
+    Returns
+    -------
+    EnsembleResult
+        Pool, quality, and representative index.
+    """
+    param_matrix = np.asarray(param_matrix, dtype=float)
+    quality = {
+        'rmse': np.asarray(rmse, dtype=float),
+        'r_squared': np.asarray(r_squared, dtype=float),
+    }
+    parameter_samples = {key: param_matrix[:, i].copy() for i, key in enumerate(parameter_keys)}
+    return EnsembleResult(
+        representative_index=select_representative_index(quality),
+        parameter_samples=parameter_samples,
+        quality_samples=quality,
+    )
+
+
+def central_spread(samples: np.ndarray, mode: str) -> tuple[float, float]:
+    """Return ``(central, spread)`` for *samples* under aggregation *mode*.
+
+    Parameters
+    ----------
+    samples : np.ndarray
+        One parameter's pool of valid-trial values.
+    mode : str
+        A key of :data:`ENSEMBLE_STATISTICS` (e.g. ``'median'`` or ``'mean'``).
+    """
+    stat = ENSEMBLE_STATISTICS[mode]
+    samples = np.asarray(samples, dtype=float)
+    return stat.central(samples), stat.spread(samples)
+
+
+def summarize(parameter_samples: dict[str, np.ndarray]) -> dict[str, dict[str, float]]:
+    """Per-parameter descriptive statistics for the Fitted Parameters table.
+
+    Returns ``{param_key: {'median', 'mad', 'mean', 'std'}}``, all drawn
+    from the :data:`ENSEMBLE_STATISTICS` primitives so the table and the
+    reported ± never diverge.
+    """
+    median = ENSEMBLE_STATISTICS['median']
+    mean = ENSEMBLE_STATISTICS['mean']
+    out: dict[str, dict[str, float]] = {}
+    for key, raw in parameter_samples.items():
+        samples = np.asarray(raw, dtype=float)
+        out[key] = {
+            'median': median.central(samples),
+            'mad': median.spread(samples),
+            'mean': mean.central(samples),
+            'std': mean.spread(samples),
+        }
+    return out

--- a/core/optimizer/filters.py
+++ b/core/optimizer/filters.py
@@ -1,7 +1,8 @@
-"""Filtering and aggregation utilities for fit results.
+"""Filtering utilities for fit results.
 
-This module provides functions to filter fit attempts by quality metrics
-(RMSE, R²) and aggregate passing fits using robust statistics (median, MAD).
+Filter multi-start fit attempts down to the *valid pool* by quality
+metrics (R², RMSE). Collapsing that pool to a reported result lives in
+:mod:`core.optimizer.ensemble`, not here.
 """
 
 from typing import List, Optional, Tuple
@@ -63,107 +64,42 @@ def filter_by_r_squared(
     return [r for r in results if r.r_squared >= min_r_squared]
 
 
-def filter_fits(
+def select_valid_fits(
     results: List[FitAttempt],
-    rmse_threshold_factor: float = 1.5,
     min_r_squared: float = 0.9,
+    rmse_threshold_factor: Optional[float] = None,
 ) -> List[FitAttempt]:
-    """Filter fit attempts by both RMSE and R² criteria.
+    """Select the valid-fit pool kept for aggregation.
 
-    Parameters
-    ----------
-    results : List[FitAttempt]
-        Fit attempts to filter.
-    rmse_threshold_factor : float
-        Multiplier for best RMSE to set threshold.
-    min_r_squared : float
-        Minimum acceptable R² value.
+    The absolute R² floor is the primary quality gate — it is an absolute
+    RMSE gate too, since R² and RMSE are monotonically related on a fixed
+    dataset. The relative RMSE trim is an *optional* extra tightening
+    (off by default): when ``rmse_threshold_factor`` is given, fits with
+    ``RMSE > best_valid_RMSE * factor`` are also dropped.
 
-    Returns
-    -------
-    List[FitAttempt]
-        Fit attempts passing both criteria.
-    """
-    filtered = filter_by_rmse(results, rmse_threshold_factor)
-    filtered = filter_by_r_squared(filtered, min_r_squared)
-    return filtered
-
-
-def compute_median_params(results: List[FitAttempt]) -> Optional[np.ndarray]:
-    """Compute median parameters from filtered fit attempts.
-
-    Parameters
-    ----------
-    results : List[FitAttempt]
-        Fit attempts to aggregate.
-
-    Returns
-    -------
-    np.ndarray or None
-        Median parameter values, or None if no results.
-    """
-    if not results:
-        return None
-
-    param_matrix = np.array([r.params for r in results])
-    return np.median(param_matrix, axis=0)
-
-
-def compute_mad(results: List[FitAttempt]) -> Optional[np.ndarray]:
-    """Compute median absolute deviation of parameters.
-
-    MAD is a robust measure of spread, less sensitive to outliers than
-    standard deviation.
-
-    Parameters
-    ----------
-    results : List[FitAttempt]
-        Fit attempts to analyze.
-
-    Returns
-    -------
-    np.ndarray or None
-        MAD for each parameter, or None if no results.
-    """
-    if not results:
-        return None
-
-    param_matrix = np.array([r.params for r in results])
-    median_params = np.median(param_matrix, axis=0)
-    mad = np.median(np.abs(param_matrix - median_params), axis=0)
-    return mad
-
-
-def aggregate_fits(
-    results: List[FitAttempt],
-    rmse_threshold_factor: float = 1.5,
-    min_r_squared: float = 0.9,
-) -> Tuple[Optional[np.ndarray], Optional[np.ndarray], int]:
-    """Filter and aggregate fit results to median parameters.
+    No convergence (``success``) gate: an attempt reaching ``R² >= floor``
+    is a good fit regardless of the optimizer's status flag, and gating on
+    ``success`` would risk discarding good fits.
 
     Parameters
     ----------
     results : List[FitAttempt]
         All fit attempts.
-    rmse_threshold_factor : float
-        Multiplier for best RMSE to set threshold.
     min_r_squared : float
-        Minimum acceptable R² value.
+        Minimum acceptable R² value (primary gate).
+    rmse_threshold_factor : float, optional
+        If set, additionally keep only fits with RMSE within this multiple
+        of the best valid fit's RMSE. ``None`` disables the trim.
 
     Returns
     -------
-    Tuple[np.ndarray, np.ndarray, int]
-        (median_params, mad, n_passing). All are None/0 if no fits pass.
+    List[FitAttempt]
+        Fit attempts forming the valid pool.
     """
-    filtered = filter_fits(results, rmse_threshold_factor, min_r_squared)
-
-    if not filtered:
-        return None, None, 0
-
-    median_params = compute_median_params(filtered)
-    mad = compute_mad(filtered)
-
-    return median_params, mad, len(filtered)
+    valid = filter_by_r_squared(results, min_r_squared)
+    if rmse_threshold_factor is not None:
+        valid = filter_by_rmse(valid, rmse_threshold_factor)
+    return valid
 
 
 def calculate_fit_metrics(

--- a/core/pipeline/__init__.py
+++ b/core/pipeline/__init__.py
@@ -3,10 +3,12 @@
 from core.pipeline.fit_pipeline import (
     FitConfig,
     FitResult,
+    apply_statistics_mode,
     bounds_from_dye_alone,
     fit_assay,
     fit_linear_assay,
     fit_measurement_set,
+    select_representative,
 )
 
 __all__ = [
@@ -16,4 +18,6 @@ __all__ = [
     'fit_assay',
     'fit_linear_assay',
     'fit_measurement_set',
+    'apply_statistics_mode',
+    'select_representative',
 ]

--- a/core/pipeline/fit_pipeline.py
+++ b/core/pipeline/fit_pipeline.py
@@ -23,7 +23,7 @@ import numpy as np
 from core.assays.base import BaseAssay
 from core.assays.dye_alone import DyeAloneAssay
 from core.data_processing.measurement_set import MeasurementSet
-from core.optimizer.ensemble import DEFAULT_STATISTICS_MODE, central_spread, collapse
+from core.optimizer.ensemble import DEFAULT_STATISTICS_MODE, ENSEMBLE_STATISTICS, central_spread, collapse
 from core.optimizer.filters import calculate_fit_metrics, select_valid_fits
 from core.optimizer.multistart import multistart_minimize
 from core.optimizer.scaling import ParamScaler
@@ -463,17 +463,21 @@ def apply_statistics_mode(result: FitResult, mode: str) -> None:
 
     if result.parameter_samples is None:
         raise ValueError('Cannot set statistics mode: result has no parameter_samples pool.')
+    if mode not in ENSEMBLE_STATISTICS:
+        raise ValueError(f"Unknown statistics mode '{mode}'. Valid modes: {sorted(ENSEMBLE_STATISTICS)}.")
 
     try:
         units = dict(ASSAY_REGISTRY[AssayType[result.assay_type]].units)
     except KeyError:
         units = {}
 
-    result.statistics_mode = mode
-    result.uncertainties = {
+    # Compute before mutating so a failure can't leave the result half-updated.
+    uncertainties = {
         key: Q_(central_spread(samples, mode)[1], units.get(key, 'dimensionless'))
         for key, samples in result.parameter_samples.items()
     }
+    result.statistics_mode = mode
+    result.uncertainties = uncertainties
 
 
 def select_representative(result: FitResult, assay: BaseAssay, index: int) -> None:
@@ -497,6 +501,10 @@ def select_representative(result: FitResult, assay: BaseAssay, index: int) -> No
     """
     if result.parameter_samples is None:
         raise ValueError('Cannot select a representative: result has no parameter_samples pool.')
+
+    pool_size = len(next(iter(result.parameter_samples.values())))
+    if not 0 <= index < pool_size:
+        raise ValueError(f'Representative index {index} out of range for pool of size {pool_size}.')
 
     rep_params = np.array([result.parameter_samples[k][index] for k in assay.parameter_keys], dtype=float)
     rmse, r_squared, x_fit, y_fit = representative_view(assay, rep_params)
@@ -592,15 +600,18 @@ def fit_assay(
                 best.rmse,
                 best.r_squared,
             )
+            hint = (
+                'All fit attempts were rejected by the quality filter. Try: (1) lowering min_r_squared, '
+                '(2) increasing n_trials, or (3) reviewing parameter bounds.'
+            )
+            if config.rmse_threshold_factor is not None:
+                hint += ' The optional RMSE-factor trim is also active — disabling it may help.'
             diag = {
                 'error': 'No fits passed filtering criteria',
                 'best_attempt_rmse': best.rmse,
                 'best_attempt_r_squared': best.r_squared,
                 'best_attempt_params': assay.params_to_dict(best.params),
-                'hint': (
-                    'All fit attempts were rejected by the quality filter. Try: (1) lowering min_r_squared, '
-                    '(2) increasing n_trials, (3) reviewing parameter bounds, or (4) disabling the RMSE-factor trim.'
-                ),
+                'hint': hint,
             }
         else:
             logger.warning(

--- a/core/pipeline/fit_pipeline.py
+++ b/core/pipeline/fit_pipeline.py
@@ -4,9 +4,10 @@ This module provides the main entry point for fitting assay data. The
 pipeline orchestrates:
 1. Loading/preparing data
 2. Running multi-start optimization
-3. Filtering results by quality metrics
-4. Aggregating to robust median estimates
-5. Computing final fit metrics
+3. Filtering to the valid-fit pool by quality metrics
+4. Collapsing the pool to a representative real fit (see
+   :mod:`core.optimizer.ensemble`)
+5. Summarising the pool's spread (median/MAD, mean/STDEV)
 """
 
 from __future__ import annotations
@@ -22,7 +23,8 @@ import numpy as np
 from core.assays.base import BaseAssay
 from core.assays.dye_alone import DyeAloneAssay
 from core.data_processing.measurement_set import MeasurementSet
-from core.optimizer.filters import calculate_fit_metrics, filter_fits
+from core.optimizer.ensemble import DEFAULT_STATISTICS_MODE, central_spread, collapse
+from core.optimizer.filters import calculate_fit_metrics, select_valid_fits
 from core.optimizer.multistart import multistart_minimize
 from core.optimizer.scaling import ParamScaler
 from core.units import Q_, Quantity
@@ -55,15 +57,20 @@ class FitResult:
     Attributes
     ----------
     parameters : dict[str, Quantity]
-        Best-fit parameter name → Quantity value.
+        Representative-fit parameter name → Quantity value. This is an
+        *actual* fit from the valid pool (the one with the highest R²),
+        not a synthetic per-parameter aggregate — so it lies on the
+        model's degenerate manifold and reconstructs ``y_fit`` exactly.
     uncertainties : dict[str, Quantity]
-        Parameter name → uncertainty (MAD of filtered fits) as Quantity.
+        Parameter name → reported spread across the valid pool, as a
+        Quantity. The spread flavour follows ``statistics_mode`` (MAD for
+        ``"median"``, STDEV for ``"mean"``).
     rmse : float
-        Root mean squared error of the fit.
+        RMSE of the representative fit.
     r_squared : float
-        Coefficient of determination.
+        R² of the representative fit.
     n_passing : int
-        Number of fits that passed filtering criteria.
+        Number of fits in the valid pool.
     n_total : int
         Total number of fit attempts.
     x_fit : Quantity
@@ -100,17 +107,27 @@ class FitResult:
     replica_fits : list[FitResult] | None
         Per-replica fit results when this is an aggregate from
         :func:`fit_measurement_set_per_replica`; ``None`` for single-signal
-        fits.  Retained for diagnostic inspection only — the reported
-        ``parameters`` and ``uncertainties`` are computed directly from
-        the pooled ``parameter_samples``, not from these.
+        fits.  Retained for diagnostic inspection only.
     parameter_samples : dict[str, np.ndarray] | None
-        One flat array per parameter key holding every passing trial's
-        parameter value (length == ``n_passing``).  In average mode this
-        is the multistart pool on the single averaged signal; in
-        per-replica mode it is the concatenation of passing trials
-        across every active replica (the pool downstream box-and-whisker
-        plots consume).  Both ``parameters`` (median) and
-        ``uncertainties`` (MAD) are computed directly from this pool.
+        One flat array per parameter key holding every valid trial's
+        parameter value (length == ``n_passing``), aligned by index.  In
+        average mode this is the multistart pool on the single averaged
+        signal; in per-replica mode it is the concatenation of valid
+        trials across every active replica.  The reported ``uncertainties``
+        and the table's Median/MAD/Mean/STDEV are computed from this pool.
+    quality_samples : dict[str, np.ndarray] | None
+        ``{"rmse": ..., "r_squared": ...}`` — per-trial fit quality for the
+        pool, aligned to ``parameter_samples`` by index.  Drives the
+        RMSE/R² distribution plots and representative selection.
+    representative_index : int | None
+        Index (into the ``parameter_samples``/``quality_samples`` arrays)
+        of the representative fit reported in ``parameters``/``rmse``/
+        ``r_squared``/``y_fit``.
+    statistics_mode : str
+        Which aggregation drives the reported ± and annotation: ``"median"``
+        (± MAD, robust default) or ``"mean"`` (± STDEV).  A display choice —
+        it never changes ``parameters`` (the representative), the curve, or
+        RMSE/R².
     """
 
     parameters: Dict[str, Quantity]
@@ -133,6 +150,9 @@ class FitResult:
     uncertainty_source: str = 'optimizer'
     replica_fits: Optional[List['FitResult']] = None
     parameter_samples: Optional[Dict[str, np.ndarray]] = None
+    quality_samples: Optional[Dict[str, np.ndarray]] = None
+    representative_index: Optional[int] = None
+    statistics_mode: str = DEFAULT_STATISTICS_MODE
 
     @property
     def success(self) -> bool:
@@ -192,6 +212,10 @@ class FitResult:
         if self.parameter_samples is not None:
             parameter_samples_serial = {k: [float(v) for v in arr] for k, arr in self.parameter_samples.items()}
 
+        quality_samples_serial: Optional[Dict[str, List[float]]] = None
+        if self.quality_samples is not None:
+            quality_samples_serial = {k: [float(v) for v in arr] for k, arr in self.quality_samples.items()}
+
         return {
             'id': self.id,
             'timestamp': self.timestamp,
@@ -214,6 +238,9 @@ class FitResult:
             'uncertainty_source': self.uncertainty_source,
             'replica_fits': replica_fits_serial,
             'parameter_samples': parameter_samples_serial,
+            'quality_samples': quality_samples_serial,
+            'representative_index': self.representative_index,
+            'statistics_mode': self.statistics_mode,
         }
 
     @classmethod
@@ -265,6 +292,11 @@ class FitResult:
         if parameter_samples_data is not None:
             parameter_samples = {k: np.asarray(v, dtype=float) for k, v in parameter_samples_data.items()}
 
+        quality_samples_data = d.get('quality_samples')
+        quality_samples: Optional[Dict[str, np.ndarray]] = None
+        if quality_samples_data is not None:
+            quality_samples = {k: np.asarray(v, dtype=float) for k, v in quality_samples_data.items()}
+
         return cls(
             parameters=parameters,
             uncertainties=uncertainties,
@@ -286,15 +318,24 @@ class FitResult:
             uncertainty_source=d.get('uncertainty_source', 'optimizer'),
             replica_fits=replica_fits,
             parameter_samples=parameter_samples,
+            quality_samples=quality_samples,
+            representative_index=d.get('representative_index'),
+            statistics_mode=d.get('statistics_mode', DEFAULT_STATISTICS_MODE),
         )
 
 
 @dataclass
 class FitConfig:
-    """Configuration for the fitting pipeline."""
+    """Configuration for the fitting pipeline.
+
+    ``rmse_threshold_factor`` is an *optional* extra trim on top of the
+    absolute R² floor (``min_r_squared``), and is off by default
+    (``None``). When set, fits with ``RMSE > best_valid_RMSE * factor`` are
+    also dropped from the valid pool.
+    """
 
     n_trials: int = 100
-    rmse_threshold_factor: float = 1.5
+    rmse_threshold_factor: Optional[float] = None
     min_r_squared: float = 0.9
     log_scale_params: Optional[List[str]] = None
     custom_bounds: Optional[Dict[str, Tuple[Quantity, Quantity]]] = None
@@ -381,6 +422,92 @@ def _wrap_params_as_quantities(
     return result
 
 
+def representative_view(
+    assay: BaseAssay,
+    params: np.ndarray,
+) -> Tuple[float, float, Quantity, Quantity]:
+    """Self-consistent reported fields for one real parameter vector.
+
+    The single source for "a parameter vector → its RMSE/R² and plotted
+    curve against *assay*'s data", used both when first reporting a fit and
+    when the user re-selects a different representative. Because *params* is
+    a real fit (on the model's degenerate manifold), the curve and metrics
+    reconstruct correctly — unlike a synthetic per-parameter aggregate.
+
+    Returns
+    -------
+    tuple[float, float, Quantity, Quantity]
+        ``(rmse, r_squared, x_fit, y_fit)``.
+    """
+    y_pred = assay.forward_model(params)
+    rmse, r_squared = calculate_fit_metrics(assay.y_data.magnitude, y_pred.magnitude)
+    x_fit, y_fit = _dense_fit_curve(assay, params)
+    return rmse, r_squared, x_fit, y_fit
+
+
+def apply_statistics_mode(result: FitResult, mode: str) -> None:
+    """Recompute the reported ± on *result* from its pool under *mode*.
+
+    Mutates *result* in place: updates ``statistics_mode`` and recomputes
+    ``uncertainties`` (the spread) from ``parameter_samples`` via
+    :func:`core.optimizer.ensemble.central_spread`. The reported value
+    (representative), curve, and RMSE/R² are unchanged — only the ± flavour
+    (MAD vs STDEV) changes. Used by the GUI median↔mean toggle (no re-fit).
+
+    Raises
+    ------
+    ValueError
+        If *result* has no ``parameter_samples`` pool to summarise.
+    """
+    from core.assays.registry import ASSAY_REGISTRY, AssayType
+
+    if result.parameter_samples is None:
+        raise ValueError('Cannot set statistics mode: result has no parameter_samples pool.')
+
+    try:
+        units = dict(ASSAY_REGISTRY[AssayType[result.assay_type]].units)
+    except KeyError:
+        units = {}
+
+    result.statistics_mode = mode
+    result.uncertainties = {
+        key: Q_(central_spread(samples, mode)[1], units.get(key, 'dimensionless'))
+        for key, samples in result.parameter_samples.items()
+    }
+
+
+def select_representative(result: FitResult, assay: BaseAssay, index: int) -> None:
+    """Re-point *result* at a different valid fit from its pool.
+
+    Mutates *result* in place: sets ``representative_index`` to *index* and
+    rebuilds ``parameters``/``rmse``/``r_squared``/``x_fit``/``y_fit`` from
+    that pooled trial via :func:`representative_view`. ``uncertainties`` and
+    the pool are unchanged — only which real fit is reported. Used by the GUI
+    when the user picks a fit from the distribution plot or the selector.
+
+    Parameters
+    ----------
+    result : FitResult
+        A successful fit carrying a ``parameter_samples`` pool.
+    assay : BaseAssay
+        Assay rebuilt from the same data (the averaged signal for
+        per-replica results) so curve/metrics match the reported data.
+    index : int
+        Index into the pooled samples of the fit to report.
+    """
+    if result.parameter_samples is None:
+        raise ValueError('Cannot select a representative: result has no parameter_samples pool.')
+
+    rep_params = np.array([result.parameter_samples[k][index] for k in assay.parameter_keys], dtype=float)
+    rmse, r_squared, x_fit, y_fit = representative_view(assay, rep_params)
+    result.representative_index = index
+    result.parameters = _wrap_params_as_quantities(rep_params, assay)
+    result.rmse = rmse
+    result.r_squared = r_squared
+    result.x_fit = x_fit
+    result.y_fit = y_fit
+
+
 def fit_assay(
     assay: BaseAssay,
     config: Optional[FitConfig] = None,
@@ -446,33 +573,22 @@ def fit_assay(
         scaler=scaler,
     )
 
-    # Keep the filtered pool around so parameter_samples can be populated —
-    # this is the full distribution of passing trials, not just their median.
-    passing_attempts = filter_fits(
+    # Select the valid pool: absolute R² floor (primary) + optional RMSE trim.
+    valid_attempts = select_valid_fits(
         all_attempts,
-        rmse_threshold_factor=config.rmse_threshold_factor,
         min_r_squared=config.min_r_squared,
+        rmse_threshold_factor=config.rmse_threshold_factor,
     )
 
-    if passing_attempts:
-        param_matrix = np.array([a.params for a in passing_attempts], dtype=float)
-        median_params = np.median(param_matrix, axis=0)
-        mad = np.median(np.abs(param_matrix - median_params), axis=0)
-        n_passing = len(passing_attempts)
-    else:
-        median_params = None
-        mad = None
-        n_passing = 0
-
     # Handle case where no fits pass
-    if median_params is None:
+    if not valid_attempts:
         if all_attempts:
             best = all_attempts[0]
             logger.warning(
-                'No fits passed filtering (n_trials=%d, rmse_factor=%.1f, min_r2=%.2f). Best attempt: RMSE=%.4e, R2=%.4f.',
+                'No fits passed filtering (n_trials=%d, min_r2=%.2f, rmse_factor=%s). Best attempt: RMSE=%.4e, R2=%.4f.',
                 config.n_trials,
-                config.rmse_threshold_factor,
                 config.min_r_squared,
+                config.rmse_threshold_factor,
                 best.rmse,
                 best.r_squared,
             )
@@ -482,7 +598,8 @@ def fit_assay(
                 'best_attempt_r_squared': best.r_squared,
                 'best_attempt_params': assay.params_to_dict(best.params),
                 'hint': (
-                    'All fit attempts were rejected by the quality filter. Try: (1) increasing rmse_threshold_factor, (2) lowering min_r_squared, (3) increasing n_trials, or (4) reviewing parameter bounds.'
+                    'All fit attempts were rejected by the quality filter. Try: (1) lowering min_r_squared, '
+                    '(2) increasing n_trials, (3) reviewing parameter bounds, or (4) disabling the RMSE-factor trim.'
                 ),
             }
         else:
@@ -510,23 +627,28 @@ def fit_assay(
             metadata=diag,
         )
 
-    # Calculate metrics for median parameters
-    y_pred = assay.forward_model(median_params)
-    rmse, r_squared = calculate_fit_metrics(y_data_mag, y_pred.magnitude)
+    # Collapse the pool: keep every valid trial, report a real representative fit.
+    keys = list(assay.parameter_keys)
+    param_matrix = np.array([a.params for a in valid_attempts], dtype=float)
+    rmse_pool = np.array([a.rmse for a in valid_attempts], dtype=float)
+    r2_pool = np.array([a.r_squared for a in valid_attempts], dtype=float)
+    ens = collapse(param_matrix, rmse_pool, r2_pool, keys)
 
-    # Build Quantity parameter dicts
-    params_q = _wrap_params_as_quantities(median_params, assay)
-    unc_q = _wrap_params_as_quantities(mad, assay)
-    x_fit, y_fit = _dense_fit_curve(assay, median_params)
+    # Reported result = the representative real fit (on-manifold, self-consistent).
+    rep_params = ens.representative_params
+    rmse, r_squared, x_fit, y_fit = representative_view(assay, rep_params)
+    params_q = _wrap_params_as_quantities(rep_params, assay)
 
-    parameter_samples = {k: param_matrix[:, i].copy() for i, k in enumerate(assay.parameter_keys)}
+    # Reported ± = spread of the pool under the default statistics mode.
+    spread_vec = np.array([central_spread(ens.parameter_samples[k], DEFAULT_STATISTICS_MODE)[1] for k in keys])
+    unc_q = _wrap_params_as_quantities(spread_vec, assay)
 
     return FitResult(
         parameters=params_q,
         uncertainties=unc_q,
         rmse=rmse,
         r_squared=r_squared,
-        n_passing=n_passing,
+        n_passing=len(valid_attempts),
         n_total=len(all_attempts),
         x_fit=x_fit,
         y_fit=y_fit,
@@ -536,7 +658,10 @@ def fit_assay(
         fit_config=_config_to_dict(config),
         measurement_set_id=measurement_set_id,
         source_file=source_file,
-        parameter_samples=parameter_samples,
+        parameter_samples=ens.parameter_samples,
+        quality_samples=ens.quality_samples,
+        representative_index=ens.representative_index,
+        statistics_mode=DEFAULT_STATISTICS_MODE,
     )
 
 
@@ -718,24 +843,18 @@ def fit_measurement_set_per_replica(
     its per-replica scaler, so parameter values from every replica
     live in the same raw-unit space.
 
-    **Aggregation semantics (approach (b), pooled):** every replica's
-    passing trials — not its pre-collapsed median — are concatenated
-    into a single flat pool (per parameter key) stored on the returned
-    ``FitResult.parameter_samples``.  The reported ``parameters`` are
-    the **median of that pool** and ``uncertainties`` are the MAD of
-    that pool.  A replica with more passing trials therefore
-    contributes proportionally more samples to the pool; this matches
-    the user-requested design (every acceptable fit counts equally).
+    **Aggregation semantics (pooled):** every replica's valid trials are
+    concatenated into a single flat pool (per parameter key) stored on the
+    returned ``FitResult.parameter_samples``, aligned with a pooled
+    ``quality_samples`` whose RMSE/R² are recomputed against the averaged
+    active-replica signal.  A replica with more valid trials contributes
+    proportionally more samples to the pool.
 
-    This is strictly richer than the earlier median-of-medians approach:
-    with N replicas × ~80 passing trials each, the pool has ~80N
-    samples; the previous aggregator collapsed the same data to N
-    points before computing MAD.
-
-    The reported ``x_fit``/``y_fit`` is the forward model evaluated at
-    the pooled median parameters on the shared concentration grid — this
-    is the "Median Fit" curve drawn in the plot.  RMSE and R² on the
-    aggregate are computed against the averaged active-replica signal.
+    The reported ``parameters``/``rmse``/``r_squared``/``y_fit`` come from
+    the **representative** pooled trial — the one with the highest R²
+    against the averaged signal, a real on-manifold fit, not a synthetic
+    per-parameter aggregate.  ``uncertainties`` are the pool's spread under
+    the default statistics mode (MAD).
 
     Failure handling: a replica that raises (degenerate scaler input,
     convergence failure, …) is skipped and recorded in the returned
@@ -759,12 +878,13 @@ def fit_measurement_set_per_replica(
     Returns
     -------
     FitResult
-        Aggregate result whose ``parameters`` and ``uncertainties`` are
-        the pooled median and MAD across every passing trial from every
-        successful replica, ``uncertainty_source == "replicate"`` (string
-        kept for backward compat with previously exported JSONs),
-        ``parameter_samples`` holds the pool, and ``replica_fits`` holds
-        the per-replica successful fits for diagnostic inspection.
+        Aggregate result whose ``parameters``/``rmse``/``r_squared`` are
+        the representative pooled trial and ``uncertainties`` the pool's
+        spread, ``uncertainty_source == "replicate"`` (string kept for
+        backward compat with previously exported JSONs),
+        ``parameter_samples``/``quality_samples`` hold the pool, and
+        ``replica_fits`` holds the per-replica successful fits for
+        diagnostic inspection.
     """
     if config is None:
         config = FitConfig()
@@ -811,7 +931,7 @@ def fit_measurement_set_per_replica(
             failures,
         )
 
-    # Pool: concatenate every replica's passing-trial samples per parameter.
+    # Pool every replica's valid trials (per parameter key), aligned by index.
     param_keys = tuple(replica_fits[0].parameter_samples.keys())
     for rr in replica_fits[1:]:
         if tuple(rr.parameter_samples.keys()) != param_keys:
@@ -821,30 +941,30 @@ def fit_measurement_set_per_replica(
     }
     pool_size = len(next(iter(pool.values())))
 
-    any_fit = replica_fits[0]
-    param_units = {k: v.units for k, v in any_fit.parameters.items()}
-    params_q: Dict[str, Any] = {}
-    unc_q: Dict[str, Any] = {}
-    for k in param_keys:
-        samples = pool[k]
-        median = float(np.median(samples))
-        mad = float(np.median(np.abs(samples - median)))
-        params_q[k] = Q_(median, param_units[k])
-        unc_q[k] = Q_(mad, param_units[k])
-
     template_assay = ms.to_assay(
         assay_cls,
         conditions=conditions,
         use_average=True,
     )
-    median_vec = np.array(
-        [float(params_q[k].magnitude) for k in template_assay.parameter_keys],
-        dtype=float,
-    )
+    keys = list(template_assay.parameter_keys)
+
+    # Recompute each pooled trial's quality against the averaged signal so the
+    # pooled representative and its reported RMSE/R² stay self-consistent.
+    param_matrix = np.column_stack([pool[k] for k in keys])
     y_avg = template_assay.y_data.magnitude
-    y_pred = template_assay.forward_model(median_vec)
-    rmse, r_squared = calculate_fit_metrics(y_avg, y_pred.magnitude)
-    x_fit, y_fit = _dense_fit_curve(template_assay, median_vec)
+    rmse_pool = np.empty(pool_size)
+    r2_pool = np.empty(pool_size)
+    for j in range(pool_size):
+        y_pred = template_assay.forward_model(param_matrix[j])
+        rmse_pool[j], r2_pool[j] = calculate_fit_metrics(y_avg, y_pred.magnitude)
+    ens = collapse(param_matrix, rmse_pool, r2_pool, keys)
+
+    # Reported result = the representative pooled trial (a real, on-manifold fit).
+    rep_params = ens.representative_params
+    rmse, r_squared, x_fit, y_fit = representative_view(template_assay, rep_params)
+    params_q = _wrap_params_as_quantities(rep_params, template_assay)
+    spread_vec = np.array([central_spread(ens.parameter_samples[k], DEFAULT_STATISTICS_MODE)[1] for k in keys])
+    unc_q = _wrap_params_as_quantities(spread_vec, template_assay)
 
     n_total_pool = sum(rr.n_total for rr in replica_fits)
 
@@ -876,5 +996,8 @@ def fit_measurement_set_per_replica(
         metadata=metadata,
         uncertainty_source='replicate',
         replica_fits=replica_fits,
-        parameter_samples=pool,
+        parameter_samples=ens.parameter_samples,
+        quality_samples=ens.quality_samples,
+        representative_index=ens.representative_index,
+        statistics_mode=DEFAULT_STATISTICS_MODE,
     )

--- a/gui/fitting_session.py
+++ b/gui/fitting_session.py
@@ -22,7 +22,7 @@ from core.assays.registry import ASSAY_REGISTRY, AssayType
 from core.data_processing.measurement_set import MeasurementSet
 from core.data_processing.plotting import prepare_plot_data
 from core.io.formats.bmg_reader import BMG_PLACEHOLDER_KEY
-from core.pipeline.fit_pipeline import FitConfig, FitResult
+from core.pipeline.fit_pipeline import FitConfig, FitResult, apply_statistics_mode, select_representative
 from gui.app_state import SessionState
 from gui.plotting.distribution_widget import DistributionWidget
 from gui.plotting.fit_summary_widget import FitSummaryWidget
@@ -420,7 +420,7 @@ class FittingSession(QWidget):
                             {
                                 'x': r.x_fit.magnitude,
                                 'y': r.y_fit.magnitude,
-                                'label': 'Median Fit',
+                                'label': 'Best Fit',
                                 'id': r.id,
                             }
                             for r in results
@@ -660,6 +660,11 @@ class FittingSession(QWidget):
         self._style_widget.widget.style_changed.connect(self._plot_widget.apply_style)
         self._style_widget.widget.style_changed.connect(self._distribution_widget.apply_style)
 
+        # Ensemble interaction: switch reported ± / pick a different representative.
+        self._summary_widget.statistics_mode_changed.connect(self._on_statistics_mode_changed)
+        self._summary_widget.representative_selected.connect(self._on_representative_selected)
+        self._distribution_widget.representative_selected.connect(self._on_representative_selected)
+
     # ------------------------------------------------------------------
     # Slots
     # ------------------------------------------------------------------
@@ -758,6 +763,38 @@ class FittingSession(QWidget):
     def _on_fit_error(self, msg: str) -> None:
         QMessageBox.warning(self, 'Fit Error', msg)
         self.status_message.emit(f'Fit failed: {msg}')
+
+    def _on_statistics_mode_changed(self, mode: str) -> None:
+        """Switch the reported ± between median±MAD and mean±STDEV (no re-fit)."""
+        results = self._state.fit_results
+        if not results:
+            return
+        result = results[-1]
+        if result.parameter_samples is None:
+            return
+        apply_statistics_mode(result, mode)
+        self._summary_widget.update_result(result)
+        # Refresh the plot annotation so its ± reflects the new mode.
+        self._plot_widget.set_fit_results(self._state.fit_results)
+
+    def _on_representative_selected(self, index: int) -> None:
+        """Report a different valid fit (from a distribution click or the selector)."""
+        ms = self._state.measurement_set
+        results = self._state.fit_results
+        if ms is None or not results:
+            return
+        result = results[-1]
+        if result.parameter_samples is None:
+            return
+        assay = ms.to_assay(
+            self._assay_panel.get_assay_class(),
+            conditions=self._assay_panel.current_conditions(),
+            use_average=True,
+        )
+        select_representative(result, assay, index)
+        self._refresh_plot()
+        self._summary_widget.update_result(result)
+        self._distribution_widget.update_result(result)
 
     # ------------------------------------------------------------------
     # Helpers

--- a/gui/plotting/distribution_widget.py
+++ b/gui/plotting/distribution_widget.py
@@ -22,8 +22,10 @@ _BOX_HALF = 0.3
 _CAP_HALF = 0.2
 _JITTER_HALF = 0.25
 
-# Fit-quality metrics shown as extra distribution subplots: key -> (title, unit).
-_QUALITY_LABELS = {'rmse': ('RMSE', 'au'), 'r_squared': ('R²', '')}
+# Fit-quality metrics shown as extra distribution subplots.
+# key -> (title, uses_signal_unit): RMSE carries the assay's signal (y) unit,
+# sourced from the registry at render time; R² is dimensionless.
+_QUALITY_METRICS = {'rmse': ('RMSE', True), 'r_squared': ('R²', False)}
 
 # Fallback per-cell logical pixel size when the live widget hasn't
 # been shown yet (e.g. headless tests, dialog opened before the
@@ -500,8 +502,16 @@ class DistributionWidget(QWidget):
             )
             plot_item.addItem(marker)
 
-        title, unit = _QUALITY_LABELS.get(metric_key, (metric_key, ''))
-        base_label = f'{title} [{fmt_unit_html(unit)}]' if unit else title
+        # RMSE label unit = the assay's signal unit from the registry (the same
+        # 'a.u.' string the main plot uses). Pass it plainly — Pint's HTML
+        # formatter mis-parses the dotted 'a.u.' alias (renders 'u a').
+        title, uses_signal_unit = _QUALITY_METRICS.get(metric_key, (metric_key, False))
+        unit = ''
+        if uses_signal_unit:
+            assay_type = self._lookup_assay_type(result.assay_type)
+            if assay_type is not None:
+                unit = ASSAY_REGISTRY[assay_type].y_unit
+        base_label = f'{title} [{unit}]' if unit else title
         plot_item._y_base_label = base_label
         left_axis = plot_item.getAxis('left')
         if hasattr(left_axis, 'exponent'):

--- a/gui/plotting/distribution_widget.py
+++ b/gui/plotting/distribution_widget.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 import pyqtgraph as pg
-from PyQt6.QtCore import Qt
+from PyQt6.QtCore import Qt, pyqtSignal
 from PyQt6.QtGui import QFont
 from PyQt6.QtWidgets import QHBoxLayout, QLabel, QStackedLayout, QWidget
 
@@ -21,6 +21,9 @@ from gui.widgets.replica_panel import _display_label
 _BOX_HALF = 0.3
 _CAP_HALF = 0.2
 _JITTER_HALF = 0.25
+
+# Fit-quality metrics shown as extra distribution subplots: key -> (title, unit).
+_QUALITY_LABELS = {'rmse': ('RMSE', 'au'), 'r_squared': ('R²', '')}
 
 # Fallback per-cell logical pixel size when the live widget hasn't
 # been shown yet (e.g. headless tests, dialog opened before the
@@ -86,10 +89,26 @@ class DistributionWidget(QWidget):
 
     **Average mode**: x-axis labeled "Pool of Fits" with no tick marks.
     One box-whisker at x=0 for the single optimizer pool.
+
+    Two extra subplots show the **RMSE** and **R²** distributions across the
+    valid fits; clicking a point in either selects that fit as the reported
+    representative (emits :attr:`representative_selected`).
+
+    Signals
+    -------
+    representative_selected(int)
+        Emitted with a pool index when the user clicks a fit-quality point.
     """
+
+    representative_selected = pyqtSignal(int)
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
+        self.setToolTip(
+            'Distribution of each parameter and of fit quality (RMSE, R²) across '
+            'all valid fits. Click a point in the RMSE or R² plot to report that '
+            'fit instead of the default best.'
+        )
         self._style: dict = dict(DEFAULT_STYLE)
         self._plots: list[pg.PlotWidget] = []
         self._result: FitResult | None = None
@@ -97,7 +116,7 @@ class DistributionWidget(QWidget):
 
         self._stack = QStackedLayout(self)
 
-        self._placeholder = QLabel('Run a fit to see parameter distributions.')
+        self._placeholder = QLabel('Run a fit to see parameter and fit-quality distributions.')
         self._placeholder.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self._placeholder.setStyleSheet('color: rgba(0,0,0,0.35); font-size: 14px;')
         self._stack.addWidget(self._placeholder)
@@ -115,7 +134,13 @@ class DistributionWidget(QWidget):
     # ------------------------------------------------------------------
 
     def update_result(self, result: FitResult) -> None:
-        """Redraw all subplots from a FitResult's parameter_samples."""
+        """Redraw all subplots from a FitResult's parameter_samples.
+
+        One subplot per parameter, then RMSE and R² fit-quality subplots
+        (when ``quality_samples`` is present). Only the parameter subplots are
+        reported by :meth:`param_keys` / exported; the quality subplots are a
+        live, clickable diagnostic for picking a representative fit.
+        """
         self._result = result
 
         if result.parameter_samples is None or not result.parameters:
@@ -125,12 +150,21 @@ class DistributionWidget(QWidget):
         param_keys = list(result.parameter_samples.keys())
         self._param_keys = list(param_keys)
 
-        self._rebuild_subplots(len(param_keys))
+        quality_keys = []
+        if result.quality_samples:
+            quality_keys = [k for k in ('rmse', 'r_squared') if k in result.quality_samples]
+
+        self._rebuild_subplots(len(param_keys) + len(quality_keys))
 
         for i, key in enumerate(param_keys):
             plot_item = self._plots[i].getPlotItem()
             self._clear_subplot(plot_item)
             self._populate_subplot(plot_item, key=key, param_idx=i, add_legend=(i == 0))
+
+        for j, metric_key in enumerate(quality_keys):
+            plot_item = self._plots[len(param_keys) + j].getPlotItem()
+            self._clear_subplot(plot_item)
+            self._populate_quality_subplot(plot_item, metric_key=metric_key)
 
         self._stack.setCurrentWidget(self._plot_container)
 
@@ -433,6 +467,81 @@ class DistributionWidget(QWidget):
 
         if add_legend:
             self._add_legend(plot_item, replica_samples is not None)
+
+    def _populate_quality_subplot(self, plot_item: pg.PlotItem, *, metric_key: str) -> None:
+        """Populate one subplot with the RMSE or R² distribution over the pool.
+
+        The strip plot is clickable: clicking a point emits
+        :attr:`representative_selected` with that fit's pool index.
+        """
+        result = self._result
+        if result is None or result.quality_samples is None or metric_key not in result.quality_samples:
+            return
+
+        values = np.asarray(result.quality_samples[metric_key], dtype=float)
+        if values.size == 0:
+            return
+        stats = _box_stats(values)
+
+        self._draw_box(plot_item, stats, 0.0)
+        self._draw_quality_strip(plot_item, values)
+        self._draw_median_line(plot_item, stats['median'], [0])
+
+        # Star the current representative so the reported fit is visible.
+        ridx = result.representative_index
+        if ridx is not None and 0 <= ridx < values.size:
+            marker = pg.ScatterPlotItem(
+                x=[0.0],
+                y=[float(values[ridx])],
+                symbol='star',
+                size=18,
+                pen=pg.mkPen(FOREGROUND_COLOR, width=1),
+                brush=pg.mkBrush(255, 215, 0, 230),
+            )
+            plot_item.addItem(marker)
+
+        title, unit = _QUALITY_LABELS.get(metric_key, (metric_key, ''))
+        base_label = f'{title} [{fmt_unit_html(unit)}]' if unit else title
+        plot_item._y_base_label = base_label
+        left_axis = plot_item.getAxis('left')
+        if hasattr(left_axis, 'exponent'):
+            left_axis.exponent = None
+        plot_item.setLabel('left', base_label)
+
+        plot_item.getAxis('bottom').setTicks([[]])
+        plot_item.setLabel('bottom', 'Pool of Fits')
+
+        title_size = self._style.get('distribution', {}).get('title_font_size', 16)
+        plot_item.setTitle(title, size=f'{title_size}pt', bold=True)
+
+        self._apply_axis_style(plot_item)
+        plot_item.setXRange(-0.8, 0.8, padding=0)
+        plot_item.enableAutoRange(axis='y')
+
+    def _draw_quality_strip(self, plot_item: pg.PlotItem, values: np.ndarray) -> None:
+        """Jittered, clickable strip — clicking a point selects that fit."""
+        rng = np.random.default_rng(7)
+        n = values.size
+        jitter = rng.uniform(-_JITTER_HALF, _JITTER_HALF, size=n)
+        scatter = pg.ScatterPlotItem(
+            x=jitter,
+            y=values,
+            size=7,
+            pen=pg.mkPen(None),
+            brush=pg.mkBrush(100, 100, 100, 130),
+            data=list(range(n)),
+        )
+        scatter.setToolTip('Click a point to report that fit as the representative.')
+        scatter.sigClicked.connect(self._on_point_clicked)
+        plot_item.addItem(scatter)
+
+    def _on_point_clicked(self, _scatter, points, *_args) -> None:
+        """Emit representative_selected with the clicked fit's pool index."""
+        if not points:
+            return
+        idx = points[0].data()
+        if idx is not None:
+            self.representative_selected.emit(int(idx))
 
     # ------------------------------------------------------------------
     # Drawing primitives (PlotItem-based)

--- a/gui/plotting/fit_summary_widget.py
+++ b/gui/plotting/fit_summary_widget.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-from PyQt6.QtCore import Qt
+import numpy as np
+from PyQt6.QtCore import Qt, pyqtSignal
 from PyQt6.QtWidgets import (
+    QComboBox,
     QFormLayout,
     QHBoxLayout,
     QHeaderView,
@@ -14,50 +16,32 @@ from PyQt6.QtWidgets import (
 )
 
 from core.assays.registry import ASSAY_REGISTRY, AssayType
+from core.optimizer.ensemble import ENSEMBLE_STATISTICS, summarize
 from core.pipeline.fit_pipeline import FitResult
 from core.units import Q_, Quantity
 from gui.plotting.labels import fmt_param, fmt_unit_html
 from gui.widgets.info_button import InfoGroupBox
 
-_UNCERTAINTY_HELP_HTML = """
-<h3>Uncertainty &mdash; what the &plusmn; value means</h3>
+_PARAMS_HELP_HTML = """
+<h3>Fitted Parameters &mdash; columns</h3>
 
-<p>The &plusmn; value next to each fitted parameter tells you <b>how
-much that parameter varies</b> across all the acceptable fits the
-fitter found. A small &plusmn; means the fitter consistently lands on
-the same value; a large one means there is real spread.</p>
+<p><b>Value</b> &mdash; the single best real fit (highest R&sup2;). This is
+the fit drawn on the plot and the trustworthy number to report; it always
+corresponds to an actual fit, never a synthetic average.</p>
 
-<p>Technically, the reported value is the <i>median</i> of the
-acceptable fits, and the &plusmn; is their <i>median absolute
-deviation</i> &mdash; a robust measure of spread that is not thrown off
-by a few outliers.</p>
+<p><b>Median / MAD</b> and <b>Mean / STDEV</b> &mdash; the centre and spread
+of each parameter across <i>all</i> valid fits.
+Median&nbsp;&plusmn;&nbsp;MAD is robust to outlier fits;
+Mean&nbsp;&plusmn;&nbsp;STDEV is the ordinary average. The
+<b>Statistics</b> selector picks which pair is reported as the &plusmn; in
+the plot annotation and the export &mdash; it does not change the Value or
+the curve.</p>
 
-<h4>Average mode</h4>
-<p>Your replicas are averaged into one curve, which is then fit many
-times from different starting points. The &plusmn; reflects how
-precisely the fitter can pin down the parameter on that averaged curve.
-This is a measure of <b>numerical precision</b> &mdash; it does not
-capture replica-to-replica variation.</p>
-
-<h4>Per-replica mode</h4>
-<p>Each replica is fit independently, and every acceptable fit from
-every replica is collected together. The &plusmn; now reflects the
-full spread &mdash; including differences between replicas. This is a
-measure of <b>experimental reproducibility</b>, which is typically the
-number you would report in a publication.</p>
-
-<h4>The Median Fit curve</h4>
-<p>The curve drawn on the plot uses the median parameter values from all
-acceptable fits. It is labelled <i>Median Fit</i> because it
-represents the middle of the distribution, not the single &ldquo;best&rdquo;
-attempt.</p>
-
-<h4>Which mode am I using?</h4>
-<p>The column header tells you: <i>&plusmn;&nbsp;Uncertainty
-(optimiser)</i> in average mode, or <i>&plusmn;&nbsp;Uncertainty
-(pool&nbsp;N=&hellip;, &hellip;&nbsp;replicas)</i> in per-replica
-mode. Switch between modes in Fit Configuration &rarr; &ldquo;Fit per
-replica&rdquo;.</p>
+<p><b>Large spread on signal coefficients is expected.</b> Only
+K<sub>a</sub> is uniquely determined; I<sub>0</sub>, I<sub>D</sub>,
+I<sub>HD</sub> trade off along a degenerate manifold, so their Median/Mean
+differ from the best-fit Value and their spread is wide. That is
+informative, not an error.</p>
 """
 
 
@@ -74,12 +58,22 @@ data variance explained by the fit, from 0 to 1. Values above 0.99 are
 typical for clean fluorescence titrations; below 0.90 suggests the model
 does not capture the data shape well.</p>
 
-<p><b>Fits passing</b> &mdash; how many of the multi-start trials produced
-acceptable results (passing both the RMSE factor and minimum R&sup2;
-thresholds). A low ratio (e.g. 5/100) means most starting points led the
-optimiser to poor solutions &mdash; consider widening bounds or increasing
-the trial budget.</p>
+<p><b>Fits passing</b> &mdash; how many of the multi-start trials cleared
+the minimum&nbsp;R&sup2; floor (plus the optional RMSE trim, if enabled) and
+form the valid pool. A low ratio (e.g. 5/100) means most starting points led
+the optimiser to poor solutions &mdash; consider widening bounds or
+increasing the trial budget.</p>
 """
+
+
+# Stat columns: (header, key in ensemble.summarize() output). The active
+# (central, spread) pair is bold-emphasised per the selected statistics mode.
+_STAT_COLUMNS = (('Median', 'median'), ('MAD', 'mad'), ('Mean', 'mean'), ('STDEV', 'std'))
+_COLUMN_HEADERS = ('Parameter', 'Value') + tuple(h for h, _ in _STAT_COLUMNS) + ('Units',)
+# Header-column indices bolded for each mode's (central, spread) pair.
+_ACTIVE_COLUMNS = {'median': (2, 3), 'mean': (4, 5)}
+# Cap the Representative selector list (pools can hold hundreds of fits).
+_MAX_REP_CHOICES = 15
 
 
 class FitSummaryWidget(QWidget):
@@ -87,27 +81,67 @@ class FitSummaryWidget(QWidget):
 
     Layout
     ------
-    - ``QGroupBox("Fitted Parameters")`` with columns:
-      Parameter | Value | +/- Uncertainty | Units
+    - ``QGroupBox("Fitted Parameters")`` with a Statistics selector and
+      columns: Parameter | Value | Median | MAD | Mean | STDEV | Units.
+      ``Value`` is the representative (best) fit; Median/MAD/Mean/STDEV are
+      the spread across all valid fits. The selector chooses which
+      central+spread pair is the reported \u00b1 (annotation + export).
     - ``QGroupBox("Fit Quality")`` with RMSE, R-squared, Fits passing.
+
+    Signals
+    -------
+    statistics_mode_changed(str)
+        Emitted when the user picks a different aggregation (``"median"`` /
+        ``"mean"``). The owner recomputes the reported \u00b1 and refreshes the
+        annotation; the value, curve, and RMSE/R\u00b2 never change.
     """
+
+    statistics_mode_changed = pyqtSignal(str)
+    representative_selected = pyqtSignal(int)
 
     def __init__(self, parent=None):
         super().__init__(parent)
 
         self._params_group = InfoGroupBox(
             'Fitted Parameters',
-            'Uncertainty: what the \u00b1 value means',
-            _UNCERTAINTY_HELP_HTML,
+            'Fitted Parameters \u2014 columns',
+            _PARAMS_HELP_HTML,
         )
-        self._table = QTableWidget(0, 4)
-        self._uncertainty_header_default = '\u00b1 Uncertainty (optimiser)'
-        self._table.setHorizontalHeaderLabels(['Parameter', 'Value', self._uncertainty_header_default, 'Units'])
+
+        # Statistics selector: which (central \u00b1 spread) is the reported \u00b1.
+        self._stats_combo = QComboBox()
+        for key, stat in ENSEMBLE_STATISTICS.items():
+            self._stats_combo.addItem(stat.label, key)
+        self._stats_combo.setToolTip(
+            'Reported \u00b1 across the valid fits: \u00b1 MAD (robust) or \u00b1 STDEV. '
+            'Changes the annotation and export only \u2014 not the value or curve.'
+        )
+        self._stats_combo.currentIndexChanged.connect(self._on_stats_combo_changed)
+
+        # Representative selector: which actual fit is reported (drives the curve).
+        self._rep_combo = QComboBox()
+        self._rep_combo.setToolTip(
+            'Which valid fit is reported and drawn. Defaults to the best (highest R\u00b2); '
+            'pick another, or click a point in the Distributions tab.'
+        )
+        self._rep_combo.currentIndexChanged.connect(self._on_rep_combo_changed)
+
+        stats_row = QHBoxLayout()
+        stats_row.addWidget(QLabel('Statistics:'))
+        stats_row.addWidget(self._stats_combo)
+        stats_row.addSpacing(16)
+        stats_row.addWidget(QLabel('Representative:'))
+        stats_row.addWidget(self._rep_combo)
+        stats_row.addStretch(1)
+
+        self._table = QTableWidget(0, len(_COLUMN_HEADERS))
+        self._table.setHorizontalHeaderLabels(list(_COLUMN_HEADERS))
         header = self._table.horizontalHeader()
         header.setStretchLastSection(False)
         header.setSectionResizeMode(QHeaderView.ResizeMode.Interactive)
         self._table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
         params_layout = QVBoxLayout(self._params_group)
+        params_layout.addLayout(stats_row)
         params_layout.addWidget(self._table)
 
         self._quality_group = InfoGroupBox('Fit Quality', 'Fit Quality', _FIT_QUALITY_HELP_HTML)
@@ -126,72 +160,131 @@ class FitSummaryWidget(QWidget):
     def update_result(self, result: FitResult) -> None:
         """Populate the widget from a ``FitResult``.
 
-        Resolves units from ``ASSAY_REGISTRY`` using ``result.assay_type``.
-
-        Parameters
-        ----------
-        result : FitResult
+        ``Value`` is the representative (best) fit; Median/MAD/Mean/STDEV are
+        computed from the valid-fit pool via
+        :func:`core.optimizer.ensemble.summarize`. Units are resolved from
+        ``ASSAY_REGISTRY`` using ``result.assay_type``.
         """
         assay_type = _lookup_assay_type(result.assay_type)
         units: dict[str, str] = {}
         if assay_type is not None:
             units = ASSAY_REGISTRY[assay_type].units
 
-        if result.uncertainty_source == 'replicate':  # JSON-compat magic value
-            pool_size = result.metadata.get('pool_size', result.n_passing)
-            n_reps = result.metadata.get('n_replicas_fit', '?')
-            header = f'\u00b1 Uncertainty (pool N={pool_size}, {n_reps} replicas)'
-        else:
-            header = self._uncertainty_header_default
-        self._table.setHorizontalHeaderLabels(['Parameter', 'Value', header, 'Units'])
+        self._set_combo_mode(result.statistics_mode)
+        self._populate_rep_combo(result)
 
         params = result.parameters
-        uncertainties = result.uncertainties
+        samples = result.parameter_samples
+        stats = summarize(samples) if samples else {}
+        pool_missing = not samples
 
         self._table.setRowCount(len(params))
         for row, (key, value) in enumerate(params.items()):
-            unc = uncertainties.get(key, float('nan'))
             unit_str = units.get(key, '')
-
-            lbl_name = QLabel(fmt_param(key))
-            lbl_name.setAlignment(Qt.AlignmentFlag.AlignCenter)
-            self._table.setCellWidget(row, 0, lbl_name)
+            self._set_cell(row, 0, fmt_param(key))
 
             val_mag = float(value.magnitude) if isinstance(value, Quantity) else float(value)
-            unc_mag = float(unc.magnitude) if isinstance(unc, Quantity) else float(unc)
+            self._set_cell(row, 1, self._fmt(val_mag, unit_str))
 
-            # Use Pint HTML formatter for proper superscript notation
-            if unit_str:
-                val_html = f'{Q_(val_mag, unit_str):.3g~H}'
-                unc_html = f'{Q_(unc_mag, unit_str):.3g~H}'
-            else:
-                val_html = f'{val_mag:.3g}'
-                unc_html = f'{unc_mag:.3g}'
-            # Strip unit from the HTML — units shown in separate column
-            val_display = val_html.rsplit(' ', 1)[0] if unit_str else val_html
-            unc_display = unc_html.rsplit(' ', 1)[0] if unit_str else unc_html
+            s = stats.get(key)
+            for col, skey in ((2, 'median'), (3, 'mad'), (4, 'mean'), (5, 'std')):
+                if s is None:
+                    self._set_cell(
+                        row,
+                        col,
+                        '—',
+                        tooltip='No fit pool stored for this result (e.g. a legacy import).',
+                    )
+                else:
+                    self._set_cell(row, col, self._fmt(s[skey], unit_str))
 
-            lbl_val = QLabel(val_display)
-            lbl_val.setAlignment(Qt.AlignmentFlag.AlignCenter)
-            lbl_val.setTextFormat(Qt.TextFormat.RichText)
-            self._table.setCellWidget(row, 1, lbl_val)
+            self._set_cell(row, 6, fmt_unit_html(unit_str))
 
-            lbl_unc = QLabel(unc_display)
-            lbl_unc.setAlignment(Qt.AlignmentFlag.AlignCenter)
-            lbl_unc.setTextFormat(Qt.TextFormat.RichText)
-            self._table.setCellWidget(row, 2, lbl_unc)
-
-            unit_html = fmt_unit_html(unit_str)
-            lbl_unit = QLabel(unit_html)
-            lbl_unit.setAlignment(Qt.AlignmentFlag.AlignCenter)
-            self._table.setCellWidget(row, 3, lbl_unit)
+        self._emphasize_active_pair(result.statistics_mode)
 
         rmse_html = f'{Q_(result.rmse, "au"):.3g~H}'
         self._rmse_label.setTextFormat(Qt.TextFormat.RichText)
         self._rmse_label.setText(rmse_html)
         self._r2_label.setText(f'{result.r_squared:.4f}')
-        self._passing_label.setText(f'{result.n_passing} / {result.n_total}')
+        passing = f'{result.n_passing} / {result.n_total}'
+        if pool_missing:
+            passing += '  (pool unavailable)'
+        self._passing_label.setText(passing)
         self._autosize_columns()
+
+    # ------------------------------------------------------------------
+    # Cell / selector helpers
+    # ------------------------------------------------------------------
+
+    def _fmt(self, magnitude: float, unit_str: str) -> str:
+        """Pint HTML value with the trailing unit stripped (units have a column)."""
+        if unit_str:
+            return f'{Q_(magnitude, unit_str):.3g~H}'.rsplit(' ', 1)[0]
+        return f'{magnitude:.3g}'
+
+    def _set_cell(self, row: int, col: int, html: str, *, tooltip: str | None = None) -> None:
+        lbl = QLabel(html)
+        lbl.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        lbl.setTextFormat(Qt.TextFormat.RichText)
+        if tooltip:
+            lbl.setToolTip(tooltip)
+        self._table.setCellWidget(row, col, lbl)
+
+    def _set_combo_mode(self, mode: str) -> None:
+        """Reflect *mode* in the selector without re-emitting the change."""
+        idx = self._stats_combo.findData(mode)
+        if idx < 0:
+            return
+        self._stats_combo.blockSignals(True)
+        self._stats_combo.setCurrentIndex(idx)
+        self._stats_combo.blockSignals(False)
+
+    def _on_stats_combo_changed(self, _index: int) -> None:
+        mode = self._stats_combo.currentData()
+        if mode is not None:
+            self.statistics_mode_changed.emit(mode)
+
+    def _populate_rep_combo(self, result: FitResult) -> None:
+        """List valid fits (best first by R²) so the user can pick which is reported."""
+        self._rep_combo.blockSignals(True)
+        self._rep_combo.clear()
+        quality = result.quality_samples
+        if quality and 'r_squared' in quality and 'rmse' in quality:
+            r2 = np.asarray(quality['r_squared'], dtype=float)
+            rmse = np.asarray(quality['rmse'], dtype=float)
+            order = [int(i) for i in np.argsort(rmse)]  # best (lowest RMSE = highest R²) first
+            shown = order[:_MAX_REP_CHOICES]
+            cur = result.representative_index
+            if cur is not None and cur not in shown:
+                shown.append(int(cur))
+            for rank, idx in enumerate(shown):
+                prefix = 'Best · ' if rank == 0 else ''
+                self._rep_combo.addItem(f'{prefix}R²={r2[idx]:.4f} · RMSE={rmse[idx]:.3g}', idx)
+            if cur is not None:
+                pos = self._rep_combo.findData(int(cur))
+                if pos >= 0:
+                    self._rep_combo.setCurrentIndex(pos)
+            self._rep_combo.setEnabled(True)
+        else:
+            self._rep_combo.addItem('—', -1)
+            self._rep_combo.setEnabled(False)
+        self._rep_combo.blockSignals(False)
+
+    def _on_rep_combo_changed(self, _index: int) -> None:
+        idx = self._rep_combo.currentData()
+        if idx is not None and idx >= 0:
+            self.representative_selected.emit(int(idx))
+
+    def _emphasize_active_pair(self, mode: str) -> None:
+        """Bold the header of the active (central, spread) pair."""
+        active = _ACTIVE_COLUMNS.get(mode, ())
+        for col in range(self._table.columnCount()):
+            item = self._table.horizontalHeaderItem(col)
+            if item is None:
+                continue
+            font = item.font()
+            font.setBold(col in active)
+            item.setFont(font)
 
     def _autosize_columns(self) -> None:
         # resizeColumnsToContents() ignores widgets set via setCellWidget(),
@@ -218,7 +311,7 @@ class FitSummaryWidget(QWidget):
     def clear(self) -> None:
         """Reset all fields to their empty state."""
         self._table.setRowCount(0)
-        self._table.setHorizontalHeaderLabels(['Parameter', 'Value', self._uncertainty_header_default, 'Units'])
+        self._table.setHorizontalHeaderLabels(list(_COLUMN_HEADERS))
         self._rmse_label.setText('\u2014')
         self._r2_label.setText('\u2014')
         self._passing_label.setText('\u2014')

--- a/gui/widgets/fit_config_panel.py
+++ b/gui/widgets/fit_config_panel.py
@@ -50,34 +50,20 @@ budget.</p>
 """
 
 _RMSE_HELP_HTML = """
-<h3>RMSE Factor &mdash; Trial Acceptance Filter</h3>
+<h3>Trim by RMSE factor &mdash; optional pool tightening</h3>
 
-<p><b>What It Does</b></p>
-<p>After all multi-start trials finish, each one is ranked by its
-root-mean-squared error to the data. Trials whose RMSE is worse than
-<i>best_RMSE &times; factor</i> are discarded before the median/MAD
-aggregation step. This removes local-minimum trials that clearly
-didn&rsquo;t find a reasonable solution.</p>
+<p><b>What it does</b></p>
+<p>Off by default. The Min&nbsp;R<sup>2</sup> floor is the primary quality
+gate and already keeps only good fits. Tick this to <i>additionally</i>
+drop valid fits whose RMSE exceeds <i>best&nbsp;RMSE &times; factor</i> —
+useful only to tighten an unusually scattered pool.</p>
 
-<p><b>The Rule</b></p>
-<p align="center"><i>keep trial if RMSE<sub>i</sub> &le; factor &middot; best_RMSE</i></p>
+<p align="center"><i>keep fit if RMSE<sub>i</sub> &le; factor &middot; best_RMSE</i></p>
 
-<p><b>Practical Values</b></p>
-<ul>
-  <li><b>1.0</b> &mdash; extremely strict, keeps only trials tied with
-      the best. Almost always too tight; the aggregate uncertainty
-      collapses.</li>
-  <li><b>1.5</b> (default) &mdash; keeps trials within 50&nbsp;% of the
-      best RMSE. A good balance.</li>
-  <li><b>3.0&ndash;5.0</b> &mdash; permissive; useful when the landscape
-      is very flat and many trials are reasonable.</li>
-</ul>
-
-<p><b>When to Change It</b></p>
-<p>If the reported K<sub>a</sub> uncertainty looks implausibly small,
-loosen the factor &mdash; the trial population was too small to estimate
-it. If the aggregate parameter is clearly wrong but the plot looks okay,
-tighten the factor to weed out partial-convergence runs.</p>
+<p><b>Note</b></p>
+<p>This only narrows the spread reported for the ensemble; it never changes
+the reported best-fit value or the plotted curve. Leave it off unless you
+have a specific reason to prune.</p>
 """
 
 _PER_REPLICA_HELP_HTML = """
@@ -87,18 +73,18 @@ _PER_REPLICA_HELP_HTML = """
 <p>All active replicas are averaged into a single curve, then the
 fitter runs one multi-start optimisation on that average. Every
 starting point that produces an acceptable fit (low RMSE, high
-R<sup>2</sup>) is kept. The reported parameter is the <i>median</i> of
-those acceptable fits and the &plusmn; value is their spread (MAD).
-This tells you how tight the optimiser landscape is &mdash; <b>not</b>
-how reproducible your experiment is.</p>
+R<sup>2</sup>) is kept. The reported value is the <i>best</i> of those
+acceptable fits and the &plusmn; value is the spread of the pool (MAD by
+default). This tells you how tight the optimiser landscape is &mdash;
+<b>not</b> how reproducible your experiment is.</p>
 
 <p><b>Per-replica mode (default, on)</b></p>
 <p>Every active replica is fit on its own with a full multi-start
 run. From each replica, every trial that passes the acceptance
 filter (R<sup>2</sup>, RMSE) is retained. All those passing trials from
 all replicas are then <b>pooled into one flat collection</b>. The
-reported parameter is the median of that pool and the &plusmn; value
-is the MAD of the same pool. This captures both the optimiser spread
+reported value is the best fit in that pool and the &plusmn; value is the
+pool's spread (MAD by default). This captures both the optimiser spread
 <i>and</i> the experimental spread across replicas in one honest
 distribution &mdash; the kind you can quote in a paper or draw
 box-and-whisker plots from.</p>
@@ -113,8 +99,8 @@ box-and-whisker plots from.</p>
       summaries &mdash; so box-whiskers, histograms, and confidence
       intervals drawn from it are statistically meaningful rather than
       based on just N&nbsp;= (number of replicas) points.</li>
-  <li>The plot curve labelled <i>Median Fit</i> is the forward model
-      evaluated at the pooled median parameters.</li>
+  <li>The plot curve labelled <i>Best Fit</i> is the forward model
+      evaluated at the representative (best) pooled fit.</li>
 </ul>
 
 <p><b>When to use per-replica mode</b></p>
@@ -139,10 +125,10 @@ box-and-whisker plots from.</p>
   <li><b>Slower</b>: each replica runs its own multi-start, so the
       fit takes roughly <i>N</i> times longer. Usually still seconds.</li>
   <li><b>Fit curve looks the same</b>: when your replicas agree well,
-      the median parameter values in per-replica mode are very close
-      to the average-mode values, so the plotted curve may look
-      unchanged. The real difference shows up in the reported
-      &plusmn;&nbsp;uncertainty, not in the curve shape.</li>
+      the representative fit in per-replica mode is very close to the
+      average-mode one, so the plotted curve may look unchanged. The real
+      difference shows up in the reported &plusmn;&nbsp;uncertainty, not in
+      the curve shape.</li>
 </ul>
 """
 
@@ -245,7 +231,7 @@ class FitConfigPanel(InfoGroupBox):
     def current_config(self) -> FitConfig:
         return FitConfig(
             n_trials=self._trials_spin.value(),
-            rmse_threshold_factor=self._rmse_spin.value(),
+            rmse_threshold_factor=(self._rmse_spin.value() if self._rmse_check.isChecked() else None),
             min_r_squared=self._r2_spin.value(),
             rescale_parameters=self._rescale_check.isChecked(),
             per_replica=self._per_replica_check.isChecked(),
@@ -253,7 +239,11 @@ class FitConfigPanel(InfoGroupBox):
 
     def set_config(self, config: FitConfig) -> None:
         self._trials_spin.setValue(config.n_trials)
-        self._rmse_spin.setValue(config.rmse_threshold_factor)
+        factor = config.rmse_threshold_factor
+        self._rmse_check.setChecked(factor is not None)
+        self._rmse_spin.setEnabled(factor is not None)
+        if factor is not None:
+            self._rmse_spin.setValue(factor)
         self._r2_spin.setValue(config.min_r_squared)
         self._rescale_check.setChecked(config.rescale_parameters)
         self._per_replica_check.setChecked(config.per_replica)
@@ -273,14 +263,21 @@ class FitConfigPanel(InfoGroupBox):
         self._trials_spin.valueChanged.connect(self.config_changed)
         form.addRow('Trials:', self._with_info(self._trials_spin, 'Trials', _TRIALS_HELP_HTML))
 
+        # Optional RMSE trim — off by default; the R² floor is the primary gate.
+        self._rmse_check = QCheckBox()
+        self._rmse_check.setChecked(FitConfig().rmse_threshold_factor is not None)  # default: off
+        self._rmse_check.setToolTip('Optionally trim the valid pool by RMSE relative to the best fit (off by default).')
         self._rmse_spin = NoScrollDoubleSpinBox()
         self._rmse_spin.setRange(1.0, 10.0)
         self._rmse_spin.setSingleStep(0.1)
         self._rmse_spin.setDecimals(2)
         self._rmse_spin.setValue(1.5)
-        self._rmse_spin.setToolTip('Trials with RMSE > (best_RMSE × factor) are discarded before aggregation.')
+        self._rmse_spin.setEnabled(self._rmse_check.isChecked())
+        self._rmse_spin.setToolTip('Drop valid fits with RMSE > (best_RMSE × factor). Only applied when enabled.')
+        self._rmse_check.toggled.connect(self._rmse_spin.setEnabled)
+        self._rmse_check.toggled.connect(self.config_changed)
         self._rmse_spin.valueChanged.connect(self.config_changed)
-        form.addRow('RMSE factor:', self._with_info(self._rmse_spin, 'RMSE factor', _RMSE_HELP_HTML))
+        form.addRow('Trim by RMSE factor:', self._rmse_trim_row())
 
         self._r2_spin = NoScrollDoubleSpinBox()
         self._r2_spin.setRange(0.0, 1.0)
@@ -312,6 +309,19 @@ class FitConfigPanel(InfoGroupBox):
             'Fit per replica:',
             self._with_info(self._per_replica_check, 'Fit per replica', _PER_REPLICA_HELP_HTML),
         )
+
+    def _rmse_trim_row(self) -> QWidget:
+        """Row: [enable checkbox] [factor spinbox] [info] for the optional trim."""
+        row = QWidget()
+        lay = QHBoxLayout(row)
+        lay.setContentsMargins(0, 0, 0, 0)
+        lay.setSpacing(15)
+        lay.addWidget(self._rmse_check)
+        self._rmse_spin.setFixedWidth(120)
+        lay.addWidget(self._rmse_spin)
+        lay.addWidget(InfoButton('RMSE factor', _RMSE_HELP_HTML))
+        lay.addStretch(1)
+        return row
 
     @staticmethod
     def _with_info(widget: QWidget, title: str, html: str) -> QWidget:

--- a/tests/integration/test_per_replica_fit.py
+++ b/tests/integration/test_per_replica_fit.py
@@ -297,10 +297,10 @@ class TestFailureHandling:
 
 
 class TestPoolAggregation:
-    """The per-replica aggregate must carry the flat pool of every
-    passing trial from every replica in `parameter_samples`, and the
-    reported parameters/uncertainties must be the pool's median/MAD —
-    NOT median-of-per-replica-medians."""
+    """The per-replica aggregate must carry the flat pool of every valid
+    trial from every replica in `parameter_samples`. The reported value is
+    the representative real trial (a row of the pool, not a per-parameter
+    aggregate), and the default-mode uncertainty is the pool's MAD."""
 
     def test_aggregate_has_parameter_samples_pool(self, noisy_pr_result):
         result = noisy_pr_result
@@ -325,13 +325,18 @@ class TestPoolAggregation:
             for k in rf.parameters.keys():
                 assert len(rf.parameter_samples[k]) == rf.n_passing
 
-    def test_pool_median_matches_reported_parameter(self, noisy_pr_result):
+    def test_reported_value_is_representative_uncertainty_is_pool_mad(self, noisy_pr_result):
         result = noisy_pr_result
+        assert result.statistics_mode == 'median'
+        ridx = result.representative_index
         for k, q in result.parameters.items():
             pool = result.parameter_samples[k]
+            # Reported value = the representative real trial (a row of the pool),
+            # NOT a per-parameter median that could land off the manifold.
+            assert float(q.magnitude) == pytest.approx(float(pool[ridx]), rel=1e-12)
+            # Default (median) mode → reported ± is the pool MAD.
             expected_median = float(np.median(pool))
             expected_mad = float(np.median(np.abs(pool - expected_median)))
-            assert float(q.magnitude) == pytest.approx(expected_median, rel=1e-12)
             assert float(result.uncertainties[k].magnitude) == pytest.approx(expected_mad, rel=1e-12)
 
     def test_serialization_round_trip_of_parameter_samples(self, noisy_pr_result):
@@ -359,7 +364,7 @@ class TestPoolAggregation:
         assert result.parameter_samples is not None
         for k, arr in result.parameter_samples.items():
             assert len(arr) == result.n_passing
-        # And the reported median/MAD agree with the pool
+        # Reported value = the representative real trial, not a per-param median.
+        ridx = result.representative_index
         for k, q in result.parameters.items():
-            pool = result.parameter_samples[k]
-            assert float(q.magnitude) == pytest.approx(float(np.median(pool)), rel=1e-12)
+            assert float(q.magnitude) == pytest.approx(float(result.parameter_samples[k][ridx]), rel=1e-12)

--- a/tests/integration/test_pipeline_e2e.py
+++ b/tests/integration/test_pipeline_e2e.py
@@ -22,6 +22,7 @@ from core.assays.gda import GDAAssay
 from core.assays.ida import IDAAssay
 from core.data_processing.measurement_set import MeasurementSet
 from core.models.equilibrium import dba_signal
+from core.optimizer.filters import calculate_fit_metrics
 from core.pipeline.fit_pipeline import (
     FitConfig,
     FitResult,
@@ -510,3 +511,42 @@ class TestBoundsMarginEdgeCases:
         )
         with pytest.raises(ValueError, match='failed'):
             bounds_from_dye_alone(r)
+
+
+# ---------------------------------------------------------------------------
+# #31: representative fit is a real fit, never a synthetic per-parameter median
+# ---------------------------------------------------------------------------
+
+
+class TestRepresentativeFitTrustworthy:
+    """Regression for #31. On the degenerate IDA signal model every valid fit
+    sits on a different point of the offset/contrast manifold, so an
+    independent per-parameter median lands *off* the manifold and reconstructs
+    worse than every real fit. The reported result must instead be an actual
+    fit (the best by R²), so its RMSE/R² are real and self-consistent."""
+
+    def test_reported_rmse_is_the_pool_minimum(self, ida_clean):
+        assay, _true = _ida_assay(ida_clean)
+        result = fit_assay(assay, FitConfig(n_trials=N_TRIALS_CLEAN, custom_bounds=GDA_IDA_RECOVERY_BOUNDS))
+
+        assert result.success
+        rmse_pool = result.quality_samples['rmse']
+        ridx = result.representative_index
+        # Reported metrics belong to the representative trial, the pool's best.
+        assert result.rmse == pytest.approx(float(rmse_pool[ridx]))
+        assert result.rmse == pytest.approx(float(rmse_pool.min()))
+        assert result.r_squared == pytest.approx(float(result.quality_samples['r_squared'].max()))
+
+    def test_representative_is_no_worse_than_the_old_per_parameter_median(self, ida_clean):
+        """The old aggregator reported the per-parameter median; on this
+        degenerate model that median reconstructs worse than the representative
+        real fit. The reported RMSE must be ≤ that median's RMSE."""
+        assay, _true = _ida_assay(ida_clean)
+        result = fit_assay(assay, FitConfig(n_trials=N_TRIALS_CLEAN, custom_bounds=GDA_IDA_RECOVERY_BOUNDS))
+
+        pool = np.column_stack([result.parameter_samples[k] for k in assay.parameter_keys])
+        median_vec = np.median(pool, axis=0)
+        y_median = assay.forward_model(median_vec).magnitude
+        rmse_median, _ = calculate_fit_metrics(assay.y_data.magnitude, y_median)
+
+        assert result.rmse <= rmse_median + 1e-12

--- a/tests/unit/gui/test_fit_summary_widget.py
+++ b/tests/unit/gui/test_fit_summary_widget.py
@@ -70,3 +70,79 @@ def test_unknown_assay_type_does_not_crash(qapp):
     widget.update_result(result)  # must not raise
 
     assert widget._table.rowCount() == 1
+
+
+@pytest.fixture
+def full_fit_result():
+    """A FitResult carrying the ensemble pool (parameter + quality samples)."""
+    from core.pipeline.fit_pipeline import FitResult
+
+    x = np.linspace(0, 1e-4, 20)
+    samples = {
+        'Ka_guest': np.array([1.0e6, 1.1e6, 0.9e6]),
+        'I0': np.array([100.0, 90.0, 110.0]),
+        'I_dye_free': np.array([5.0e4, 5.1e4, 4.9e4]),
+        'I_dye_bound': np.array([8.0e4, 8.1e4, 7.9e4]),
+    }
+    quality = {
+        'rmse': np.array([0.006, 0.005, 0.007]),
+        'r_squared': np.array([0.997, 0.998, 0.996]),
+    }
+    return FitResult(
+        # Representative = index 1 (best RMSE / R²).
+        parameters={'Ka_guest': 1.1e6, 'I0': 90.0, 'I_dye_free': 5.1e4, 'I_dye_bound': 8.1e4},
+        uncertainties={'Ka_guest': 1e5, 'I0': 10.0, 'I_dye_free': 1e3, 'I_dye_bound': 1e3},
+        rmse=0.005,
+        r_squared=0.998,
+        n_passing=3,
+        n_total=10,
+        x_fit=x,
+        y_fit=x * 1.05,
+        assay_type='GDA',
+        model_name='equilibrium_4param',
+        parameter_samples=samples,
+        quality_samples=quality,
+        representative_index=1,
+        statistics_mode='median',
+    )
+
+
+def test_seven_columns_with_stats_populated(qapp, full_fit_result):
+    from gui.plotting.fit_summary_widget import _COLUMN_HEADERS, FitSummaryWidget
+
+    widget = FitSummaryWidget()
+    widget.update_result(full_fit_result)
+
+    assert widget._table.columnCount() == 7
+    headers = [widget._table.horizontalHeaderItem(c).text() for c in range(7)]
+    assert headers == list(_COLUMN_HEADERS)
+    # Median / MAD / Mean / STDEV cells are populated (not the '—' placeholder).
+    for col in (2, 3, 4, 5):
+        cell = widget._table.cellWidget(0, col)
+        assert cell is not None and cell.text() not in ('', '—')
+
+
+def test_statistics_mode_toggle_emits(qapp, full_fit_result):
+    from gui.plotting.fit_summary_widget import FitSummaryWidget
+
+    widget = FitSummaryWidget()
+    widget.update_result(full_fit_result)
+    captured = []
+    widget.statistics_mode_changed.connect(captured.append)
+
+    widget._stats_combo.setCurrentIndex(widget._stats_combo.findData('mean'))
+    assert captured == ['mean']
+
+
+def test_representative_selector_emits_pool_index(qapp, full_fit_result):
+    from gui.plotting.fit_summary_widget import FitSummaryWidget
+
+    widget = FitSummaryWidget()
+    widget.update_result(full_fit_result)
+    captured = []
+    widget.representative_selected.connect(captured.append)
+
+    # Items are ordered best-first by RMSE (argsort -> pool indices [1, 0, 2]);
+    # selecting the 3rd item reports pool index 2.
+    widget._rep_combo.setCurrentIndex(2)
+    assert captured == [2]

--- a/tests/unit/test_ensemble.py
+++ b/tests/unit/test_ensemble.py
@@ -1,0 +1,100 @@
+"""Unit tests for the ensemble-collapse module.
+
+Pins the single-source collapse behaviour: representative selection, the
+statistics registry (central tendency + spread), and the per-parameter
+summary the GUI table reads.
+"""
+
+import numpy as np
+import pytest
+
+from core.optimizer import ensemble
+
+# ---------------------------------------------------------------------------
+# Statistics registry
+# ---------------------------------------------------------------------------
+
+
+class TestStatisticsRegistry:
+    def test_registry_offers_median_and_mean(self):
+        assert set(ensemble.ENSEMBLE_STATISTICS) == {'median', 'mean'}
+        assert ensemble.DEFAULT_STATISTICS_MODE == 'median'
+
+    def test_central_spread_median_is_median_and_mad(self):
+        # [1, 2, 3]: median=2; |dev|=[1,0,1] → MAD=1 (computed independently).
+        central, spread = ensemble.central_spread(np.array([1.0, 2.0, 3.0]), 'median')
+        assert central == pytest.approx(2.0)
+        assert spread == pytest.approx(1.0)
+
+    def test_central_spread_mean_is_mean_and_sample_std(self):
+        # [1, 2, 3]: mean=2; sample std (ddof=1) = 1.0 (hand-computed).
+        central, spread = ensemble.central_spread(np.array([1.0, 2.0, 3.0]), 'mean')
+        assert central == pytest.approx(2.0)
+        assert spread == pytest.approx(1.0)
+
+    def test_single_sample_has_zero_spread(self):
+        """One sample → no dispersion defined; both modes report 0 (no NaN)."""
+        for mode in ensemble.ENSEMBLE_STATISTICS:
+            central, spread = ensemble.central_spread(np.array([7.0]), mode)
+            assert central == pytest.approx(7.0)
+            assert spread == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Representative selection
+# ---------------------------------------------------------------------------
+
+
+class TestSelectRepresentativeIndex:
+    def test_picks_highest_r_squared(self):
+        quality = {'rmse': np.array([0.03, 0.01, 0.02]), 'r_squared': np.array([0.98, 0.999, 0.99])}
+        assert ensemble.select_representative_index(quality) == 1
+
+    def test_highest_r_squared_is_lowest_rmse(self):
+        """On a fixed dataset the two criteria agree by construction."""
+        quality = {'rmse': np.array([0.5, 0.1, 0.3]), 'r_squared': np.array([0.90, 0.999, 0.95])}
+        idx = ensemble.select_representative_index(quality)
+        assert idx == int(np.argmin(quality['rmse']))
+
+
+# ---------------------------------------------------------------------------
+# collapse
+# ---------------------------------------------------------------------------
+
+
+class TestCollapse:
+    def test_pools_and_aligns_by_index(self):
+        pm = np.array([[10.0, 100.0], [20.0, 50.0], [30.0, 75.0]])
+        rmse = np.array([0.02, 0.01, 0.03])
+        r2 = np.array([0.99, 0.999, 0.98])
+        res = ensemble.collapse(pm, rmse, r2, ['Ka', 'I0'])
+
+        np.testing.assert_array_equal(res.parameter_samples['Ka'], [10.0, 20.0, 30.0])
+        np.testing.assert_array_equal(res.parameter_samples['I0'], [100.0, 50.0, 75.0])
+        np.testing.assert_array_equal(res.quality_samples['rmse'], rmse)
+        np.testing.assert_array_equal(res.quality_samples['r_squared'], r2)
+
+    def test_representative_is_the_best_real_row(self):
+        pm = np.array([[10.0, 100.0], [20.0, 50.0], [30.0, 75.0]])
+        rmse = np.array([0.02, 0.01, 0.03])
+        r2 = np.array([0.99, 0.999, 0.98])
+        res = ensemble.collapse(pm, rmse, r2, ['Ka', 'I0'])
+
+        assert res.representative_index == 1
+        # Representative is an actual row of the pool, not a per-column aggregate.
+        np.testing.assert_array_equal(res.representative_params, [20.0, 50.0])
+
+
+# ---------------------------------------------------------------------------
+# summarize (table columns)
+# ---------------------------------------------------------------------------
+
+
+class TestSummarize:
+    def test_returns_median_mad_mean_std_per_key(self):
+        samples = {'Ka': np.array([1.0, 2.0, 3.0])}
+        out = ensemble.summarize(samples)['Ka']
+        assert out['median'] == pytest.approx(2.0)
+        assert out['mad'] == pytest.approx(1.0)
+        assert out['mean'] == pytest.approx(2.0)
+        assert out['std'] == pytest.approx(1.0)  # sample std, ddof=1

--- a/tests/unit/test_ensemble.py
+++ b/tests/unit/test_ensemble.py
@@ -56,6 +56,11 @@ class TestSelectRepresentativeIndex:
         idx = ensemble.select_representative_index(quality)
         assert idx == int(np.argmin(quality['rmse']))
 
+    def test_r_squared_ties_broken_by_lowest_rmse(self):
+        """When R² ties (e.g. all 0 for constant y, ss_tot==0), pick lowest RMSE."""
+        quality = {'rmse': np.array([0.9, 0.4, 0.7]), 'r_squared': np.array([0.0, 0.0, 0.0])}
+        assert ensemble.select_representative_index(quality) == 1
+
 
 # ---------------------------------------------------------------------------
 # collapse

--- a/tests/unit/test_fit_results.py
+++ b/tests/unit/test_fit_results.py
@@ -156,3 +156,25 @@ class TestSerialization:
         d = r.to_dict()
         restored = FitResult.from_dict(d)
         assert np.isnan(restored.uncertainties['Ka_guest'].magnitude)
+
+
+class TestEnsembleMutators:
+    """Fail-fast contracts on the public pipeline mutation helpers."""
+
+    def test_apply_statistics_mode_rejects_unknown_mode(self):
+        from core.pipeline.fit_pipeline import apply_statistics_mode
+
+        r = _sample_fit_result()
+        before = dict(r.uncertainties)
+        with pytest.raises(ValueError, match='Unknown statistics mode'):
+            apply_statistics_mode(r, 'bogus')
+        # Rejected up front — no partial mutation.
+        assert r.statistics_mode == 'median'
+        assert r.uncertainties == before
+
+    def test_select_representative_rejects_out_of_range_index(self):
+        from core.pipeline.fit_pipeline import select_representative
+
+        r = _sample_fit_result()  # pool size 3
+        with pytest.raises(ValueError, match='out of range'):
+            select_representative(r, None, 99)  # index validated before the assay is used

--- a/tests/unit/test_fit_results.py
+++ b/tests/unit/test_fit_results.py
@@ -40,6 +40,18 @@ def _sample_fit_result(**overrides) -> FitResult:
         fit_config={'n_trials': 100, 'rmse_threshold_factor': 1.5},
         measurement_set_id='abc123',
         source_file='data/GDA_system.txt',
+        parameter_samples={
+            'Ka_guest': np.array([1.4e6, 1.5e6, 1.6e6]),
+            'I0': np.array([-1.0, 0.0, 1.0]),
+            'I_dye_free': np.array([4.9e7, 5.0e7, 5.1e7]),
+            'I_dye_bound': np.array([2.9e8, 3.0e8, 3.1e8]),
+        },
+        quality_samples={
+            'rmse': np.array([45.0, 42.0, 48.0]),
+            'r_squared': np.array([0.997, 0.998, 0.996]),
+        },
+        representative_index=1,
+        statistics_mode='median',
     )
     defaults.update(overrides)
     return FitResult(**defaults)
@@ -97,6 +109,13 @@ class TestSerialization:
         assert restored.timestamp == original.timestamp
         np.testing.assert_array_almost_equal(restored.x_fit.magnitude, original.x_fit.magnitude)
         np.testing.assert_array_almost_equal(restored.y_fit.magnitude, original.y_fit.magnitude)
+        # Ensemble fields round-trip too
+        for k in original.parameter_samples:
+            np.testing.assert_array_almost_equal(restored.parameter_samples[k], original.parameter_samples[k])
+        for k in original.quality_samples:
+            np.testing.assert_array_almost_equal(restored.quality_samples[k], original.quality_samples[k])
+        assert restored.representative_index == original.representative_index
+        assert restored.statistics_mode == original.statistics_mode
 
     def test_from_dict_missing_optional_fields(self):
         """from_dict handles missing optional keys gracefully."""

--- a/tests/unit/test_optimizer.py
+++ b/tests/unit/test_optimizer.py
@@ -7,8 +7,7 @@ Covers:
 - generate_initial_guesses: empty bounds, single/zero trials, log-scale
 - multistart_minimize: convergence, sorting, failure handling
 - filter_by_rmse / filter_by_r_squared: empty input, thresholds
-- compute_median_params / compute_mad: empty, single, known values
-- aggregate_fits: empty after filtering, single/multiple passing
+- select_valid_fits: R² floor gate, optional RMSE trim, #31 regression
 - calculate_fit_metrics: perfect fit, constant y, known values
 """
 
@@ -16,12 +15,10 @@ import numpy as np
 import pytest
 
 from core.optimizer.filters import (
-    aggregate_fits,
     calculate_fit_metrics,
-    compute_mad,
-    compute_median_params,
     filter_by_r_squared,
     filter_by_rmse,
+    select_valid_fits,
 )
 from core.optimizer.multistart import FitAttempt, generate_initial_guesses, multistart_minimize
 
@@ -242,116 +239,47 @@ class TestFilterByRSquared:
 
 
 # ---------------------------------------------------------------------------
-# compute_median_params
+# select_valid_fits
 # ---------------------------------------------------------------------------
 
 
-class TestComputeMedianParams:
-    def test_empty_returns_none(self):
-        assert compute_median_params([]) is None
-
-    def test_single_result(self):
-        a = _make_attempt([3.0, 7.0])
-        result = compute_median_params([a])
-        np.testing.assert_array_equal(result, [3.0, 7.0])
-
-    def test_odd_count(self):
-        attempts = [
-            _make_attempt([1.0]),
-            _make_attempt([3.0]),
-            _make_attempt([5.0]),
-        ]
-        result = compute_median_params(attempts)
-        assert result[0] == pytest.approx(3.0)
-
-    def test_even_count(self):
-        attempts = [
-            _make_attempt([2.0]),
-            _make_attempt([4.0]),
-        ]
-        result = compute_median_params(attempts)
-        assert result[0] == pytest.approx(3.0)
-
-
-# ---------------------------------------------------------------------------
-# compute_mad
-# ---------------------------------------------------------------------------
-
-
-class TestComputeMad:
-    def test_empty_returns_none(self):
-        assert compute_mad([]) is None
-
-    def test_single_result_is_zero(self):
-        a = _make_attempt([3.0, 7.0])
-        result = compute_mad([a])
-        np.testing.assert_array_equal(result, [0.0, 0.0])
-
-    def test_known_mad_value(self):
-        """MAD of [1, 2, 3]: median=2, |deviations|=[1, 0, 1], MAD=1."""
-        attempts = [
-            _make_attempt([1.0]),
-            _make_attempt([2.0]),
-            _make_attempt([3.0]),
-        ]
-        result = compute_mad(attempts)
-        assert result[0] == pytest.approx(1.0)
-
-    def test_asymmetric_data(self):
-        """MAD of [1, 2, 3, 100]: median=2.5, |dev|=[1.5, 0.5, 0.5, 97.5], MAD=1.0."""
-        attempts = [
-            _make_attempt([1.0]),
-            _make_attempt([2.0]),
-            _make_attempt([3.0]),
-            _make_attempt([100.0]),
-        ]
-        result = compute_mad(attempts)
-        assert result[0] == pytest.approx(1.0)
-
-
-# ---------------------------------------------------------------------------
-# aggregate_fits
-# ---------------------------------------------------------------------------
-
-
-class TestAggregateFits:
+class TestSelectValidFits:
     def test_empty_input(self):
-        median, mad, n = aggregate_fits([])
-        assert median is None
-        assert mad is None
-        assert n == 0
+        assert select_valid_fits([], min_r_squared=0.9) == []
 
-    def test_all_filtered_out(self):
-        """All results have low R² → none pass filtering."""
+    def test_r_squared_floor_is_the_gate(self):
+        """The absolute R² floor decides membership; below-floor fits drop."""
         attempts = [
-            _make_attempt([1.0], rmse=0.1, r_squared=0.5),
-            _make_attempt([2.0], rmse=0.2, r_squared=0.3),
+            _make_attempt([1.0], rmse=0.01, r_squared=0.99),
+            _make_attempt([2.0], rmse=0.02, r_squared=0.5),
         ]
-        median, mad, n = aggregate_fits(attempts, min_r_squared=0.9)
-        assert median is None
-        assert mad is None
-        assert n == 0
+        valid = select_valid_fits(attempts, min_r_squared=0.9)
+        assert len(valid) == 1
+        assert valid[0].r_squared == 0.99
 
-    def test_single_passing_fit(self):
+    def test_keeps_good_fit_the_old_relative_rmse_trim_discarded(self):
+        """Regression for #31: a genuinely good fit just outside 1.5×best RMSE
+        must NOT be discarded. The absolute R² floor keeps it; the old
+        relative-RMSE filter (default on) would have cut it."""
         attempts = [
-            _make_attempt([5.0], rmse=0.01, r_squared=0.99),
-            _make_attempt([10.0], rmse=0.5, r_squared=0.5),
+            _make_attempt([1.0], rmse=0.01, r_squared=0.999),  # best
+            _make_attempt([1.1], rmse=0.02, r_squared=0.995),  # good, but > 1.5×0.01
         ]
-        median, mad, n = aggregate_fits(attempts, min_r_squared=0.9)
-        assert n == 1
-        assert median[0] == pytest.approx(5.0)
-        np.testing.assert_array_equal(mad, [0.0])
+        valid = select_valid_fits(attempts, min_r_squared=0.99)
+        assert len(valid) == 2  # both survive on the absolute floor
+        # The old relative-RMSE trim (1.5×min) would have dropped the second.
+        assert len(filter_by_rmse(attempts, 1.5)) == 1
 
-    def test_multiple_passing(self):
+    def test_optional_rmse_trim_applies_when_set(self):
+        """When rmse_threshold_factor is given it further trims the R²-passing
+        pool relative to the best valid fit."""
         attempts = [
-            _make_attempt([4.0], rmse=0.01, r_squared=0.99),
-            _make_attempt([5.0], rmse=0.01, r_squared=0.99),
-            _make_attempt([6.0], rmse=0.01, r_squared=0.99),
+            _make_attempt([1.0], rmse=0.01, r_squared=0.999),
+            _make_attempt([1.1], rmse=0.02, r_squared=0.995),
         ]
-        median, mad, n = aggregate_fits(attempts, min_r_squared=0.9)
-        assert n == 3
-        assert median[0] == pytest.approx(5.0)
-        assert mad[0] == pytest.approx(1.0)
+        valid = select_valid_fits(attempts, min_r_squared=0.99, rmse_threshold_factor=1.5)
+        assert len(valid) == 1
+        assert valid[0].rmse == 0.01
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_plotting_data.py
+++ b/tests/unit/test_plotting_data.py
@@ -75,7 +75,7 @@ class TestPrepPlotDataFits:
         data = prepare_plot_data(ms, fit_results=[fr])
 
         assert len(data['fits']) == 1
-        assert data['fits'][0]['label'] == 'Median Fit'
+        assert data['fits'][0]['label'] == 'Best Fit'
         np.testing.assert_array_equal(data['fits'][0]['x'], fr.x_fit.magnitude)
         assert data['fits'][0]['id'] == fr.id
 


### PR DESCRIPTION
## Why
After a fit runs ~100 multi-start trials the app collapsed them into one result that wasn't trustworthy (#31):

- **Good fits were discarded.** The RMSE filter kept fits within `1.5 × best_RMSE` — a band *relative to the best fit* — so the better the best fit, the tighter the cut, dropping individually-excellent fits.
- **The reported result was untrustworthy.** It was a per-parameter *median*, not any real fit. The signal coefficients (`I0`, `I_dye_free`, `I_dye_bound`) are structurally degenerate, so each good fit sits on a different point of the degenerate manifold; the independent per-parameter median lands *off* that manifold and reconstructs worse than every real fit. (Measured on an IDA fit: median RMSE ≈ 9e-2 vs the best real fit ≈ 2e-5.)

## What changed
- **One home for the collapse** — `core/optimizer/ensemble.py` owns representative selection and an explicit statistics registry (adding an aggregation mode = one entry). Both pipeline paths (average + per-replica) and the GUI read from it.
- **Keep valid fits** — the valid pool is gated by the absolute R² floor; the relative-RMSE trim is now opt-in and **off by default** (R² and RMSE are monotonic on a fixed dataset, so the floor already bounds RMSE).
- **Report a real fit** — the reported parameters, curve, and RMSE/R² come from an actual fit (highest R² ≡ lowest RMSE), never a synthetic vector.
- **See the spread** — the Fitted Parameters table gains **Median / MAD / Mean / STDEV** columns; a Statistics selector switches the reported ± (annotation + export) between median±MAD and mean±STDEV with no re-fit. The value and curve never move.
- **Pick a different fit** — RMSE and R² **distribution plots** across the valid fits; click a point (or use the ranked selector) to report a different representative.

## How to verify
- `uv run pytest` (411 passing). Key regressions:
  - `tests/unit/test_optimizer.py::TestSelectValidFits` — good fits are no longer discarded by the relative band.
  - `tests/integration/test_pipeline_e2e.py::TestRepresentativeFitTrustworthy` — reported RMSE equals the pool minimum and is ≤ the old per-parameter median.
- In the app (`uv run run_app.py` → **Demo IDA**): the Fitted Parameters table shows the new columns; flip **Statistics** median↔mean and only the ± changes; open the **Distributions** tab and click an RMSE/R² point to re-select the representative.

## Notes / flags
- `FitConfig.rmse_threshold_factor` is now `Optional[float]` (None = off); the GUI exposes it as an opt-in checkbox.
- Removed the unused `aggregate_fits` / `compute_median_params` / `compute_mad` helpers and their tests (dead code).
- `FitResult` gains `quality_samples`, `representative_index`, `statistics_mode` — all serialized; pre-existing JSON exports still load (the fields default sensibly).

Closes #31
